### PR TITLE
FDG-4998 Adjust bar chart legend font and spacing above legend

### DIFF
--- a/src/layouts/explainer/sections/national-debt/national-debt.jsx
+++ b/src/layouts/explainer/sections/national-debt/national-debt.jsx
@@ -668,7 +668,7 @@ export const DebtBreakdownSection = (({ sectionId }) => {
     // which doesn't seem to happen naturally when nivo has a flex container
     const svgChart = document.querySelector('[data-testid="breakdownChart"] svg');
     if (svgChart) {
-      svgChart.setAttribute('viewBox', '0 0 524 468');
+      svgChart.setAttribute('viewBox', '0 0 524 500');
       svgChart.setAttribute('height', '100%');
       svgChart.setAttribute('width', '100%');
     }
@@ -806,7 +806,7 @@ export const DebtBreakdownSection = (({ sectionId }) => {
                         direction: 'row',
                         justify: false,
                         translateX: -104,
-                        translateY: 60,
+                        translateY: 90,
                         itemsSpacing: 2,
                         itemWidth: 250,
                         itemHeight: 40,


### PR DESCRIPTION
No change in coverage.

Note: The font size had already been corrected and equals that displayed in the mocks (14px / 0.875rem) so I only adjusted the legend spacing. Since the legend spacing is matrix based and dependent on the size of the parent nivo chart, I couldn't really put down an exact pixel amount for the margin, so I adjusted the positioning of the legends with the aid of a pixel ruler to approximate the 24px of top margin. 