### PR TITLE
FDG 5405 Padding and spacing adjustments, grid line adjustments

### DIFF
--- a/src/layouts/explainer/sections/national-debt/national-debt.jsx
+++ b/src/layouts/explainer/sections/national-debt/national-debt.jsx
@@ -795,6 +795,7 @@ export const GrowingNationalDebtSection = withWindowSize(({ sectionId, width }) 
                     colors={debtExplainerPrimary}
                     useMesh={true}
                     enableGridY={true}
+                    gridYValues={8}
                     enableGridX={false}
                     enableCrosshair={false}
                     animate={true}

--- a/src/layouts/explainer/sections/national-debt/national-debt.module.scss
+++ b/src/layouts/explainer/sections/national-debt/national-debt.module.scss
@@ -162,7 +162,7 @@
   .headerContainer {
     display: flex;
     justify-content: space-evenly;
-    margin-bottom: 2.5rem;
+    margin-bottom: 2rem;
 
     div {
       text-align: center;
@@ -340,7 +340,10 @@
   }
 
   .growingNationalDebtSectionGraphContainer, .debtBreakdownSectionGraphContainer, .debtTrendsOverTimeSectionGraphContainer {
-    padding: 22px;
+    padding-top: 22px;
+    padding-left: 22px;
+    padding-right: 22px;
+
 
     .title {
       font-size: $font-size-18;
@@ -361,6 +364,7 @@
 
     .footerContainer {
       padding-top: 1rem;
+      padding-bottom: 2rem;
 
       p {
         font-size: $font-size-14;


### PR DESCRIPTION
Here are the specific design review comments addressed in this PR: 

1. Let’s close the gap a bit between the data headline (2022 and 135%) and the chart itself, and aim for balance between what’s above and below. A suggestion would be 2rem/32px.
2. To reduce chart clutter, we’ll take out the intermediate lines between the increments on the y-axis.
3. Increase the spacing between the footer text and the background to be about 2 rem/32px. Right now it’s a more narrow gap compared to the top
![2022-06-03_debt-trends_spacing](https://user-images.githubusercontent.com/90636470/171924508-e3718bdf-5dfd-4ce0-8987-5684a2d1c918.png)
.