### PR TITLE
FDG-5405 changed loading order of grid lines

### DIFF
--- a/src/layouts/explainer/sections/national-debt/national-debt.jsx
+++ b/src/layouts/explainer/sections/national-debt/national-debt.jsx
@@ -751,9 +751,9 @@ export const GrowingNationalDebtSection = withWindowSize(({ sectionId, width }) 
                     data={exampleData}
                     theme={chartBorderTheme}
                     layers={[
-                      'axes',
                       'grid',
                       'lines',
+                      'axes',
                       CustomPoint,
                       'mesh'
                     ]}


### PR DESCRIPTION
This PR satisfies the following design points: 

1. Can we also have the horizontal increment lines go behind the dark y-axis line? This should go for the same on the x-axis too. It creates little noticeable notches in the current order.
2. For the x-axis line color, are we able to match it to the deeper y-axis color? It’s currently much lighter in comparison and difficult to see.
![2022-06-03_debt-trends_chart-adjustments](https://user-images.githubusercontent.com/90636470/171942302-91293c17-2abf-4cdf-8265-56efba51756a.png)

