### PR TITLE
FDG-5405 adjusted header item spacing

### DIFF
--- a/src/layouts/explainer/sections/national-debt/national-debt.module.scss
+++ b/src/layouts/explainer/sections/national-debt/national-debt.module.scss
@@ -161,7 +161,8 @@
 
   .headerContainer {
     display: flex;
-    justify-content: space-evenly;
+    justify-content: center;
+    gap: 1rem;
     margin-bottom: 2rem;
 
     div {


### PR DESCRIPTION
Addresses the following design comments: 

1. Currently the data points at the top “headline” are spaced farther apart and would like to see if they can connected a little closer together like in the Zeplin mock
![2022-06-03_debt-trends_data-headline](https://user-images.githubusercontent.com/90636470/171954933-c85d8814-38b7-48ee-a98b-d08b89a2ea8a.png)
![2022-06-03_debt-trends_data-headline-dev](https://user-images.githubusercontent.com/90636470/171954938-dfe64bee-2ce0-41e9-8187-0b4ee18397c6.png)
.