### PR TITLE
FDG-5316 Fix for incorrect sitemap url listed in robots.txt

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -124,7 +124,7 @@ module.exports = {
       resolve: `gatsby-plugin-robots-txt`,
       options: {
         host: 'https://fiscaldata.treasury.gov/',
-        sitemap: 'https://fiscaldata.treasury.gov/sitemap.xml',
+        sitemap: 'https://fiscaldata.treasury.gov/sitemap/sitemap-index.xml',
         resolveEnv: () => process.env.BUILD_ENV,
         env: {
           'prod': {


### PR DESCRIPTION
My research for the ticket confirms that that national debt is added automatically to the sitemap in with the correct url in any environment where it is rendered; however, this small code change addresses a related issue that likely makes the sitemap invisible to some crawlers.

https://federal-spending-transparency.atlassian.net/browse/FDG-5316

unit test line coverage: 89.25