### PR TITLE
FDG-5246 Changed color of un highlighted topics header (Design Review)

### DIFF
--- a/src/components/site-header/site-header.module.scss
+++ b/src/components/site-header/site-header.module.scss
@@ -52,7 +52,7 @@
     background-color: inherit;
     border-bottom: 2px solid transparent;
     font-size: 1rem;
-    color: $font-title;
+    color: #666666;
     height: 55px;
     min-width: 81px;
   }


### PR DESCRIPTION
No change in coverage
Addresses the following: 

The hex color of “topics” was 555555 instead of 666666 to match the rest of the navigation label colors (and Zeplin)
![2022-06-21_topics-link](https://user-images.githubusercontent.com/90636470/174827390-5c70aa27-cce7-47c9-994a-a1479dbec96a.png)
.