### PR TITLE
FDG-4704 Updates from design review 

### DIFF
--- a/src/layouts/explainer/sections/national-debt/national-debt.jsx
+++ b/src/layouts/explainer/sections/national-debt/national-debt.jsx
@@ -839,7 +839,7 @@ export const GrowingNationalDebtSection = withWindowSize(({ sectionId, width }) 
           <VisualizationCallout color={debtExplainerPrimary}>
             <p>
               Over the past 100 years, the U.S. federal debt has increased
-              from {simplifyNumber(startValue, true)} in {startYear} to {simplifyNumber(value, true)} in {year}
+              from {simplifyNumber(startValue, true)} in {startYear} to {simplifyNumber(value, true)} in {year}.
             </p>
           </VisualizationCallout>
         </div>

--- a/src/layouts/explainer/sections/national-debt/national-debt.jsx
+++ b/src/layouts/explainer/sections/national-debt/national-debt.jsx
@@ -839,7 +839,7 @@ export const GrowingNationalDebtSection = withWindowSize(({ sectionId, width }) 
           <VisualizationCallout color={debtExplainerPrimary}>
             <p>
               Over the past 100 years, the U.S. federal debt has increased
-              from {simplifyNumber(startValue, true)} in {startYear} to {simplifyNumber(value, true)} in {startYear}
+              from {simplifyNumber(startValue, true)} in {startYear} to {simplifyNumber(value, true)} in {year}
             </p>
           </VisualizationCallout>
         </div>

--- a/src/transform/explainer-pages-config.js
+++ b/src/transform/explainer-pages-config.js
@@ -9,7 +9,7 @@ const explainerPagesSource = {
     },
     heroImage: {
       heading: 'What is the national debt?',
-      subHeading: `The national debt is the total amount of outstanding borrowings by the U.S. Federal
+      subHeading: `The national debt is the total amount of outstanding borrowing by the U.S. Federal
       Government accumulated over the nation’s history.`
     },
     relatedDatasets: [ "015-BFS-2014Q3-065", "015-BFS-2014Q3-071", "015-BFS-2014Q1-11", "015-BFS-2014Q3-056" ]


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-4704

1. Remove the “s” in borrowings
2. Add a period to the end of the chart callout.