### PR TITLE
FDG-5724 US National debt over 100 years chart should display highlighted year data element as 'Fiscal Year'

### DIFF
--- a/src/layouts/explainer/sections/national-debt/national-debt.jsx
+++ b/src/layouts/explainer/sections/national-debt/national-debt.jsx
@@ -804,7 +804,7 @@ export const GrowingNationalDebtSection = withWindowSize(({ sectionId, width }) 
               <div className={headerContainer}>
                 <div>
                   <div className={header}>{displayDate}</div>
-                  <span className={subHeader}>Year</span>
+                  <span className={subHeader}>Fiscal Year</span>
                 </div>
                 <div>
                   <div className={header}>{displayValue}</div>


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-5724

