### PR TITLE
FDG-5652 Changed fiscal quarters used in GDP calc

### DIFF
--- a/src/layouts/explainer/sections/national-debt/national-debt.jsx
+++ b/src/layouts/explainer/sections/national-debt/national-debt.jsx
@@ -667,7 +667,6 @@ export const GrowingNationalDebtSection = withWindowSize(({ sectionId, width }) 
                 year: i
               })
             }
-            console.log(averagedGDPByYear);
             const debtToGDP = [];
             averagedGDPByYear.forEach(GDPEntry => {
               const record = debtData.find(entry => entry.record_date.includes(GDPEntry.year));


### PR DESCRIPTION
No change in coverage
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-5652