### PR TITLE
FDG-5866 Troubleshoot build memory

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,9 +16,6 @@ module.exports = {
   siteMetadata: {
     siteUrl: 'https://fiscaldata.treasury.gov'
   },
-  flags: {
-    LMDB_STORE: true
-  },
   plugins: [
     // ////// IMPORTANT: Google Analytics Plugin must be the first item in this array //////
     {


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-5866

Turn off experimental gatsby build flag that optimizes for speed but locally consumes more memory.