### PR TITLE
FDG-4652 Solution that detects when the October MTS data is available, the copy will drop the "- Oct 2021

### DIFF
--- a/src/layouts/explainer/heros/national-deficit/national-deficit-hero.spec.js
+++ b/src/layouts/explainer/heros/national-deficit/national-deficit-hero.spec.js
@@ -31,6 +31,8 @@ describe('National Deficit Hero', () => {
     expect(await getByText("2021, the federal government", {exact: false})).toBeInTheDocument();
     expect(await getByText("government spent $2.77 trillion", {exact: false})).toBeInTheDocument();
     expect(await getByText('period last year (Oct 2021', {exact: false})).toBeInTheDocument();
+    expect(await getByText('Jun 2021), our ', {exact: false})).toBeInTheDocument();
+
     global.fetch.mockRestore();
   });
 

--- a/src/layouts/explainer/heros/national-deficit/national-deficit-hero.spec.js
+++ b/src/layouts/explainer/heros/national-deficit/national-deficit-hero.spec.js
@@ -30,7 +30,9 @@ describe('National Deficit Hero', () => {
     expect(await getByText("down arrow", {exact: false})).toBeInTheDocument();
     expect(await getByText("2021, the federal government", {exact: false})).toBeInTheDocument();
     expect(await getByText("government spent $2.77 trillion", {exact: false})).toBeInTheDocument();
+    expect(await getByText('period last year (Oct 2021', {exact: false})).toBeInTheDocument();
     global.fetch.mockRestore();
   });
+
 
 });

--- a/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
+++ b/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
@@ -170,11 +170,14 @@ const NationalDeficitHero = ({glossary}): JSX.Element => {
         </p>
       </div>
       <div className={footNotes}>
-        <p>
-          Compared to the national deficit total for the same period last year
-          (Oct {previousFiscalYear} - {currentRecordMonth} {previousCalendarYear}),
+        {currentRecordMonth === 'Oct' ?<p>Compared to the same period last year
+            (Oct {previousFiscalYear} - {currentRecordMonth} {previousCalendarYear}),
+            our national deficit has {deficitStatus}.
+          </p> : <p>Compared to the same period last year
+          (Oct {previousFiscalYear}),
           our national deficit has {deficitStatus}.
         </p>
+        }
       </div>
       <div className={deficitBoxContainer}>
         <div className={deficitBox}>

--- a/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
+++ b/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
@@ -149,7 +149,7 @@ const NationalDeficitHero = ({glossary}): JSX.Element => {
       fiscal year (FY)
     </GlossaryTerm>
 
-  const changeNationaDeficitFooter = currentRecordMonth === 'Oct' ?
+  const changeNationaDeficitFooter = (currentRecordMonth === 'Oct') ?
     <p>Compared to the same period last year
       (Oct {previousFiscalYear}),
       our national deficit has {deficitStatus}.

--- a/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
+++ b/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
@@ -149,6 +149,16 @@ const NationalDeficitHero = ({glossary}): JSX.Element => {
       fiscal year (FY)
     </GlossaryTerm>
 
+  const changeNationaDeficitFooter = currentRecordMonth === 'Oct' ?
+    <p>Compared to the same period last year
+      (Oct {previousFiscalYear}),
+      our national deficit has {deficitStatus}.
+    </p>:
+    <p>Compared to the same period last year
+      (Oct {previousFiscalYear} - {currentRecordMonth} {previousCalendarYear}),
+      our national deficit has {deficitStatus}.
+    </p> ;
+
   return (
     <>
       <p className={`${heroImageSubHeading} ${deficit}`}>A deficit occurs when the
@@ -170,14 +180,7 @@ const NationalDeficitHero = ({glossary}): JSX.Element => {
         </p>
       </div>
       <div className={footNotes}>
-        {currentRecordMonth === 'Oct' ?<p>Compared to the same period last year
-            (Oct {previousFiscalYear} - {currentRecordMonth} {previousCalendarYear}),
-            our national deficit has {deficitStatus}.
-          </p> : <p>Compared to the same period last year
-          (Oct {previousFiscalYear}),
-          our national deficit has {deficitStatus}.
-        </p>
-        }
+        {changeNationaDeficitFooter}
       </div>
       <div className={deficitBoxContainer}>
         <div className={deficitBox}>


### PR DESCRIPTION
FDG-4652
-Changed the wording of the National Deficit Flip card display footer.
-Gave a dynamic feature to the footer to change wording if its Oct to not including another date after words.
Code Coverage:   89.32 