### PR TITLE
Fdg 5801 - Add Spending Explainer to Site Nav

### DIFF
--- a/src/components/site-header/mobile-menu/mobile-menu.jsx
+++ b/src/components/site-header/mobile-menu/mobile-menu.jsx
@@ -75,16 +75,21 @@ const MobileMenu = () => {
                       AMERICA'S FINANCE GUIDE
                     </div>
                     <div className={styles.explainerLinkContainer}>
-                      <Link to="/national-debt/"
-                            className={styles.explainerLink}
-                            onClick={() => topicsClickHandler('Debt')}
+                      <Link to="/federal-spending/"
+                        className={styles.explainerLink}
                       >
-                        Debt
+                        Spending
                       </Link>
                       <Link to="/national-deficit/"
-                            className={styles.explainerLink}
+                        className={styles.explainerLink}
                       >
                         Deficit
+                      </Link>
+                      <Link to="/national-debt/"
+                        className={styles.explainerLink}
+                        onClick={() => topicsClickHandler('Debt')}
+                      >
+                        Debt
                       </Link>
                     </div>
                     <div className={styles.AFGHeader}>

--- a/src/components/site-header/mobile-menu/mobile-menu.spec.js
+++ b/src/components/site-header/mobile-menu/mobile-menu.spec.js
@@ -69,5 +69,6 @@ describe('MobileMenu actions', () => {
     expect(getByTestId('about')).toBeDefined();
     expect(getByText('Debt')).toBeDefined();
     expect(getByText('Deficit')).toBeDefined();
+    expect(getByText('Spending')).toBeDefined();
   });
 });

--- a/src/components/site-header/site-header.jsx
+++ b/src/components/site-header/site-header.jsx
@@ -51,19 +51,17 @@ const SiteHeader = ({ lowerEnvMsg, location }) => {
 
   const topicsPageLinks = [
     {
-      title: 'Debt',
-      to: '/national-debt/',
-      testId: 'debt'
-    },
-    {
-      title: 'Deficit',
-      to: '/national-deficit/',
-      testId: 'deficit'
-    },
-    {
       title: 'Spending',
       to: '/federal-spending/',
       testId: 'spending'
+    },{
+      title: 'Deficit',
+      to: '/national-deficit/',
+      testId: 'deficit'
+    },{
+      title: 'Debt',
+      to: '/national-debt/',
+      testId: 'debt'
     }
   ]
 

--- a/src/components/site-header/site-header.jsx
+++ b/src/components/site-header/site-header.jsx
@@ -59,6 +59,11 @@ const SiteHeader = ({ lowerEnvMsg, location }) => {
       title: 'Deficit',
       to: '/national-deficit/',
       testId: 'deficit'
+    },
+    {
+      title: 'Spending',
+      to: '/federal-spending/',
+      testId: 'spending'
     }
   ]
 

--- a/src/components/site-header/site-header.spec.js
+++ b/src/components/site-header/site-header.spec.js
@@ -72,6 +72,7 @@ describe('SiteHeader', () => {
     fireEvent.mouseEnter(getByTestId('topicsButton'));
     expect(getByText('Debt')).toBeDefined();
     expect(getByText('Deficit')).toBeDefined();
+    expect(getByText('Spending')).toBeDefined();
   })
 
   it('expects that all of the header links are not active/highlighted by default', () => {

--- a/src/transform/explainer-pages-config.js
+++ b/src/transform/explainer-pages-config.js
@@ -38,7 +38,7 @@ const explainerPagesSource = {
       description: `Explore federal spending by category or agency and learn how much the United
       States government spends each year.`
     },
-    prodReady: false,
+    prodReady: true,
     heroImage: {
       heading: 'How much has the U.S. government spent this year?',
       subHeading: ''


### PR DESCRIPTION
The Spending explainer is included in the navigation header under the 'AMERICA'S FINANCE GUIDE' heading with the following title: 'Spending'. The URL for the page should be:  https://fiscaldata.treasury.gov/federal-spending/

The order of AFG pages under the Topics > America’s Finance Guide' heading should be set as follows: Spending, Deficit, Debt.

The Spending explainer site navigation should display as expected on both desktop and mobile. 

Code Coverage: 89.48