### PR TITLE
FDG-6037 Copy should say 'section' and not 'chapter'

### DIFF
--- a/src/layouts/explainer/sections/federal-spending/spending-trends/spending-trends.jsx
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/spending-trends.jsx
@@ -8,7 +8,7 @@ import {
 export const SpendingTrends = () => {
   return (
     <div>
-      <p className={comingSoon}>Coming Soon: A chapter exploring changes
+      <p className={comingSoon}>Coming Soon: A section exploring changes
         in spending trends over time, and how GDP factors into those trends.</p>
     </div>
   );


### PR DESCRIPTION
Changed chapter to section in the spending trends sections
https://federal-spending-transparency.atlassian.net/browse/FDG-6037