### PR TITLE
FDG-6045 Populate data variables from API in homepage tile promoting Spending explainer

### DIFF
--- a/src/components/topics-section/explainer-tile/explainer-tile-helper.js
+++ b/src/components/topics-section/explainer-tile/explainer-tile-helper.js
@@ -1,3 +1,35 @@
+import React, {useEffect, useState} from "react";
+import {apiPrefix, basicFetch} from "../../../utils/api-utils";
+import {getShortForm} from "../../../layouts/explainer/heros/hero-helper";
+
+export const SpendingBodyGenerator = () => {
+  const fields = 'fields=current_fytd_net_outly_amt,record_fiscal_year,record_date';
+  const filter = 'filter=line_code_nbr:eq:5691';
+  const sort = 'sort=-record_date';
+  const pagination = 'page[size]=1';
+  const endpointUrl
+    = `v1/accounting/mts/mts_table_5?${fields}&${filter}&${sort}&${pagination}`;
+  const spendingUrl = `${apiPrefix}${endpointUrl}`;
+  const [amount, setAmount] = useState('5');
+  const [year, setYear] = useState('1111');
+
+  useEffect(() => {
+    basicFetch(`${spendingUrl}`)
+      .then((res) => {
+        if (res.data) {
+          const data = res.data[0];
+          setAmount(data.current_fytd_net_outly_amt);
+          setYear(data.record_fiscal_year);
+        }
+      })
+  }, []);
+
+  return (<>The U.S. government has spent ${getShortForm(amount, 1, false)}{' '}
+    in fiscal year {year} to ensure the well-being of the people of the United States.
+    Learn more about spending categories, types of spending, and spending trends over time.</>);
+};
+
+
 export const pageTileMap = {
 
   'debt': {
@@ -17,13 +49,7 @@ export const pageTileMap = {
       'year {YYYY (current fiscal year)} to ensure the well-being of the people of the ' +
       'United States. Learn more about spending categories, types of spending, and ' +
       'spending trends over time.',
-    bodyGenerator: () =>  {
-      //placeholder for fetch logic
-      const amount = 'XX.X trillion'
-      const year = 'YYYY'
-    return `The U.S. government has spent $${amount}
-    in fiscal year ${year} to ensure the well-being of the people of the United States.
-    Learn more about spending categories, types of spending, and spending trends over time.`},
+    bodyGenerator: SpendingBodyGenerator,
     altText: 'The US Treasury building is placed next to a row of homes. A pair of hands ' +
       'exchange money in the foreground.',
     desktopImage: 'homepage_spending_1200x630',

--- a/src/components/topics-section/explainer-tile/explainer-tile.spec.js
+++ b/src/components/topics-section/explainer-tile/explainer-tile.spec.js
@@ -1,6 +1,12 @@
 import React from 'react';
-import { render } from "@testing-library/react"
+import {
+  render,
+  waitFor
+} from "@testing-library/react";
 import ExplainerTile from "./explainer-tile";
+import {SpendingBodyGenerator} from './explainer-tile-helper';
+import fetchMock from 'fetch-mock';
+import {mockSpendingHeroData} from "../../../layouts/explainer/explainer-test-helper";
 
 const testTiles = {
   'pageName': {
@@ -119,4 +125,16 @@ describe('Explainer Tile', () => {
     expect(getByRole('presentation')).toBeInTheDocument();
     expect(getByRole('presentation')).toHaveAttribute('alt', 'altText');
   });
+});
+
+describe('Spending Body Generator ', () => {
+  it('renders the amount and year', async () => {
+    fetchMock.get(`begin:https://www.transparency.treasury.gov/services/api/fiscal_service/`,
+      mockSpendingHeroData, {overwriteRoutes: true}, {repeat: 1}
+    )
+    const {getByText} = render(<SpendingBodyGenerator />);
+    await waitFor(() => getByText("$4.5 trillion", {exact:false}));
+    expect(await getByText("in fiscal year 2022", {exact: false})).toBeInTheDocument();
+  });
+
 });


### PR DESCRIPTION
FDG-6045

With the Support of Tom

-Added the api calls to the explainer tile helper.

-Added a test to make sure the data populates.

https://federal-spending-transparency.atlassian.net/browse/FDG-6045

Test Coverage: 89.44 
