### PR TITLE
FDG-5695 Add new dataset to UAT: Federal Credit Similar Maturity Rates

### DIFF
--- a/env/uat.js
+++ b/env/uat.js
@@ -4,6 +4,30 @@ module.exports = {
   DATA_DOWNLOAD_BASE_URL: 'https://uat.fiscaldata.treasury.gov',
   WEB_SOCKET_BASE_URL: 'wss://downloads.uat.fiscaldata.treasury.gov/main',
   EXPERIMENTAL_WHITELIST: ['chartingConfigurationTool', 'experimental-page'],
+  ADDITIONAL_DATASETS: {
+    "015-BFS-2014Q3-039": {
+      "seoConfig": {
+        "pageTitle": "Federal Credit Similar Maturity Rates",
+        "description": "Interest rates for time deposit securities with a maturity " +
+          "of one month up to 40 years and a daily rate for demand deposits.",
+        "keywords": "Debt, Interest and Exchange Rates"
+      },
+      "topics": [
+        "debt",
+        "interest-exchange-rates"
+      ],
+      "relatedDatasets": [
+        "015-BFS-2014Q3-037",
+        "015-BFS-2014Q1-11",
+        "015-BFS-2014Q3-076",
+        "015-BFS-2014Q1-03",
+        "015-BFS-2014Q1-13",
+        "015-BFS-2014Q3-103"
+      ],
+      "slug": "/fed-credit-similar-maturity-rates/",
+      "currentDateButton": "byMonth"
+    }
+  },
   ADDITIONAL_ENDPOINTS: {
     '27': {
       'endpoint': 'v1/debt/mspd/mspd_table_1',

--- a/env/uat.js
+++ b/env/uat.js
@@ -17,12 +17,8 @@ module.exports = {
         "interest-exchange-rates"
       ],
       "relatedDatasets": [
-        "015-BFS-2014Q3-037",
-        "015-BFS-2014Q1-11",
-        "015-BFS-2014Q3-076",
-        "015-BFS-2014Q1-03",
-        "015-BFS-2014Q1-13",
-        "015-BFS-2014Q3-103"
+        "015-BFS-2014Q3-093",
+        "015-BFS-2014Q3-056"
       ],
       "slug": "/fed-credit-similar-maturity-rates/",
       "currentDateButton": "byMonth"

--- a/src/transform/endpointConfig.js
+++ b/src/transform/endpointConfig.js
@@ -1810,6 +1810,24 @@ const endpointConfig = {
     'valueFieldOptions': [
       'rate'
     ]
+  },
+  '180': {
+    'endpoint': 'v1/accounting/od/federal_maturity_rates',
+      'dateField': 'record_date',
+      'downloadName': 'FederalCreditSimilarMaturityRates',
+      'dataDisplays': [
+      {
+        'title': 'By Fiscal Year',
+        "dimensionField": "record_fiscal_year"
+      }
+    ],
+      'valueFieldOptions': [
+      'one_year_or_less',
+      'between_1_and_5_years',
+      'between_5_and_10_years',
+      'between_10_and_20_years',
+      'twenty_years_or_greater'
+    ]
   }
 };
 


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-5695

Line coverage: 89.5%

Note: to see dataset page, site will need to be built as for the UAT env.