### PR TITLE
FDG-6045 Populate data variables from API in homepage tile promoting Spending explainer

### DIFF
--- a/src/components/topics-section/explainer-tile/explainer-tile-helper.js
+++ b/src/components/topics-section/explainer-tile/explainer-tile-helper.js
@@ -10,21 +10,22 @@ export const SpendingBodyGenerator = () => {
   const endpointUrl
     = `v1/accounting/mts/mts_table_5?${fields}&${filter}&${sort}&${pagination}`;
   const spendingUrl = `${apiPrefix}${endpointUrl}`;
-  const [amount, setAmount] = useState('5');
-  const [year, setYear] = useState('1111');
+  const [amount, setAmount] = useState('0');
+  const [year, setYear] = useState('null');
 
   useEffect(() => {
     basicFetch(`${spendingUrl}`)
       .then((res) => {
         if (res.data) {
           const data = res.data[0];
-          setAmount(data.current_fytd_net_outly_amt);
+          const currentTotalSpending = data.current_fytd_net_outly_amt;
+          setAmount(currentTotalSpending);
           setYear(data.record_fiscal_year);
         }
       })
   }, []);
-
-  return (<>The U.S. government has spent ${getShortForm(amount, 1, false)}{' '}
+console.log(amount);
+  return (<>The U.S. government has spent ${getShortForm(amount, 2, false)}{' '}
     in fiscal year {year} to ensure the well-being of the people of the United States.
     Learn more about spending categories, types of spending, and spending trends over time.</>);
 };

--- a/src/components/topics-section/explainer-tile/explainer-tile-helper.js
+++ b/src/components/topics-section/explainer-tile/explainer-tile-helper.js
@@ -18,13 +18,12 @@ export const SpendingBodyGenerator = () => {
       .then((res) => {
         if (res.data) {
           const data = res.data[0];
-          const currentTotalSpending = data.current_fytd_net_outly_amt;
-          setAmount(currentTotalSpending);
+          setAmount(data.current_fytd_net_outly_amt);
           setYear(data.record_fiscal_year);
         }
       })
   }, []);
-console.log(amount);
+
   return (<>The U.S. government has spent ${getShortForm(amount, 2, false)}{' '}
     in fiscal year {year} to ensure the well-being of the people of the United States.
     Learn more about spending categories, types of spending, and spending trends over time.</>);

--- a/src/components/topics-section/explainer-tile/explainer-tile.spec.js
+++ b/src/components/topics-section/explainer-tile/explainer-tile.spec.js
@@ -133,7 +133,7 @@ describe('Spending Body Generator ', () => {
       mockSpendingHeroData, {overwriteRoutes: true}, {repeat: 1}
     )
     const {getByText} = render(<SpendingBodyGenerator />);
-    await waitFor(() => getByText("$4.5 trillion", {exact:false}));
+    await waitFor(() => getByText("$4.52 trillion", {exact:false}));
     expect(await getByText("in fiscal year 2022", {exact: false})).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Changed the spending decimal to show two decimal places instead of one.