### PR TITLE
FDG-5951 Add the 'Coming Soon' design to the Table of Contents (ToC) section of the Revenue Explainer page

### DIFF
--- a/src/layouts/explainer/sections/government-revenue/government-revenue.jsx
+++ b/src/layouts/explainer/sections/government-revenue/government-revenue.jsx
@@ -59,6 +59,7 @@ const governmentRevenueSections = [
     index: 4,
     id: governmentRevenueSectionIds[4],
     title: "Federal Revenue Trends and the U.S. Economy",
+    comingSoon: true,
     component: (glossary, cpiDataByYear) => <FederalRevenueTrendsAndUSEconomy />
   },
 ]


### PR DESCRIPTION
Added comingSoon flag to the revenue page
https://federal-spending-transparency.atlassian.net/browse/FDG-5951

AC:

The 'Coming Soon' flag is added to the Table of Contents (ToC) for the 'Federal Revenue Trends and the U.S. Economy' section.

The flag font and stylings match the design in Zeplin.

The flag is responsive and displays as expected on desktop and mobile.

CC: 89.69 