### PR TITLE
FDG-6001 Hook in the Data for Variable Data Elements on the Revenue Explainer page

### DIFF
--- a/src/layouts/explainer/heros/government-revenue/government-revenue-hero.spec.js
+++ b/src/layouts/explainer/heros/government-revenue/government-revenue-hero.spec.js
@@ -24,10 +24,10 @@ describe('Government Revenue Hero', () => {
     expect(await getByText("in fiscal year 2022", {exact: false})).toBeInTheDocument();
     expect(await getByText("Fiscal Year-to-Date (since October 2021)", {exact: false}))
       .toBeInTheDocument();
-    expect(await getByText("Compared to the national revenue of $3.3 trillion", {exact: false}))
+    expect(await getByText("Compared to the national revenue of $3.32 trillion", {exact: false}))
       .toBeInTheDocument();
     expect(await getByText("(Oct 2020 - Jun 2021)", {exact: false})).toBeInTheDocument();
-    expect(await getByText("national revenue has increased by $786.6 billion", {exact: false}))
+    expect(await getByText("national revenue has increased by $787 billion", {exact: false}))
       .toBeInTheDocument();
 
     global.fetch.mockRestore();
@@ -41,10 +41,10 @@ describe("Pill data section", () => {
     )
     const fetchSpy = jest.spyOn(global, 'fetch');
 
-    const {getByText, getByRole} = render(<GovernmentRevenueHero />);
+    const {getByText, getByRole, getAllByText} = render(<GovernmentRevenueHero />);
     expect(fetchSpy).toBeCalled();
 
-    await waitFor(() => getByText("$787 B", {exact:false}));
+    await waitFor(() => getAllByText("$787 B", {exact:false}));
     expect(await getByRole("img", {name: "up arrow"})).toBeInTheDocument();
     expect(await getByText("24%", {exact: false})).toBeInTheDocument();
 
@@ -57,10 +57,10 @@ describe("Pill data section", () => {
     )
     const fetchSpy = jest.spyOn(global, 'fetch');
 
-    const {getByText, getByRole} = render(<GovernmentRevenueHero />);
+    const {getByText, getByRole, getAllByText} = render(<GovernmentRevenueHero />);
     expect(fetchSpy).toBeCalled();
 
-    await waitFor(() => getByText("$213 B", {exact:false}));
+    await waitFor(() => getAllByText("$213 B", {exact:false}));
     expect(await getByRole("img", {name: "down arrow"})).toBeInTheDocument();
     expect(await getByText("5%", {exact: false})).toBeInTheDocument();
 

--- a/src/layouts/explainer/heros/government-revenue/government-revenue-hero.tsx
+++ b/src/layouts/explainer/heros/government-revenue/government-revenue-hero.tsx
@@ -96,7 +96,7 @@ const GovernmentRevenueHero = (): JSX.Element => {
         <div className={footNotesPillData}>
           <p>
             Compared to the national revenue of $
-            {getShortForm(priorYearRevenue.toString(), 1, false)} for the same
+            {getShortForm(priorYearRevenue.toString(), 2, false)} for the same
             period last year (
             {getFootNotesDateRange(
               priorFiscalYear,
@@ -104,7 +104,7 @@ const GovernmentRevenueHero = (): JSX.Element => {
               recordCalendarMonth
             )}
             ) national revenue has {revenueChangeLabel} by $
-            {getShortForm(revenueChange.toString(), 1, false)}.
+            {getShortForm(revenueChange.toString(), 0, false)}.
           </p>
           {getPillData(
             revenueChange,


### PR DESCRIPTION
Changed abbrv in hero to match data feedback (https://data-transparency-bfs.slack.com/archives/CKM2LCAF6/p1663616161308949)
No change in coverage
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-6001