### PR TITLE
FDG-6044 Remove AFG blub from hero section on the Debt, Deficit and Spending explainer pages

### DIFF
--- a/src/layouts/explainer/hero-image/hero-image.spec.js
+++ b/src/layouts/explainer/hero-image/hero-image.spec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render } from "@testing-library/react";
 import HeroImage from "./hero-image";
-import NationalDebtHero from "../heros/national-debt/national-debt-hero";
 import { setGlobalFetchResponse } from "../../../utils/mock-utils";
 import { mockExplainerPageResponse } from "../explainer-test-helper";
 
@@ -38,7 +37,6 @@ describe('National Debt Hero', () => {
     const subHeading = 'mock sub-heading';
     const primaryColor = 'test';
     const secondaryColor = 'test';
-    const children = <NationalDebtHero />
 
     const { getAllByRole, getByTestId } = render(
       <HeroImage
@@ -47,14 +45,8 @@ describe('National Debt Hero', () => {
         primaryColor={primaryColor}
         secondaryColor={secondaryColor}
         width={0}
-        children={children}
       />
     );
 
-    const flagIcon = getAllByRole('img', {hidden:true}, {name:"flag-usa"});
-
-    expect(getByTestId('nationalDebtCallout')).toBeInTheDocument();
-    expect(flagIcon).toHaveLength(1);
-    expect(flagIcon[0]).toBeInTheDocument();
   })
 })

--- a/src/layouts/explainer/heros/federal-spending/federal-spending-hero.tsx
+++ b/src/layouts/explainer/heros/federal-spending/federal-spending-hero.tsx
@@ -2,12 +2,8 @@ import {
   counterContainerSpending,
   footNotes,
   footNotesPillData,
-  heroImageCallout,
   heroImageSubHeading,
-  icon
 } from "../../hero-image/hero-image.module.scss";
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faFlagUsa} from "@fortawesome/free-solid-svg-icons";
 import React, {useEffect, useState} from "react";
 import CustomLink from "../../../../components/links/custom-link/custom-link";
 import {apiPrefix, basicFetch} from "../../../../utils/api-utils";
@@ -41,9 +37,7 @@ const FederalSpendingHero = (): JSX.Element => {
   const [spendingChange, setSpendingChange] = useState( 0);
   const [spendingPercentChange, setSpendingPercentChange] = useState(0);
 
-  const debt = <CustomLink url={'/americas-finance-guide/national-debt/'}>Debt</CustomLink>;
-  const deficit = <CustomLink url={'/americas-finance-guide/national-deficit/'}>Deficit</CustomLink>;
-  const mts =
+    const mts =
     <CustomLink url={'/datasets/monthly-treasury-statement/outlays-of-the-u-s-government'}>
       Monthly Treasury Statement (MTS)
     </CustomLink>
@@ -109,15 +103,6 @@ const FederalSpendingHero = (): JSX.Element => {
           {getPillData(spendingChange, spendingPercentChange, spendingChangeLabel,
             true, spendingExplainerLightSecondary)}
         </div>
-      </div>
-      <div className={heroImageCallout} >
-        <FontAwesomeIcon icon={faFlagUsa} className={icon} />
-        <p>
-          This topic is the third of four U.S. government financial concepts from Your Guide to
-          America’s Finances with more being added in the coming months. We’ll help you learn
-          more about money coming in (Revenue), money going out (Spending), and
-          the {deficit} and {debt}.
-        </p>
       </div>
     </>
   );

--- a/src/layouts/explainer/heros/national-debt/national-debt-hero.tsx
+++ b/src/layouts/explainer/heros/national-debt/national-debt-hero.tsx
@@ -1,10 +1,8 @@
-import {counterContainer, counterSourceInfo, heroImageCallout,calloutContainer, icon} from "../../hero-image/hero-image.module.scss";
+import {counterContainer, counterSourceInfo} from "../../hero-image/hero-image.module.scss";
 import SplitFlapDisplay from "../../../../components/split-flap-display/split-flap-display";
 import CustomLink from "../../../../components/links/custom-link/custom-link";
 import React, {useEffect, useState} from "react";
 import {apiPrefix, basicFetch} from "../../../../utils/api-utils";
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faFlagUsa} from "@fortawesome/free-solid-svg-icons";
 import Analytics from "../../../../utils/analytics/analytics";
 
 const NationalDebtHero = (): JSX.Element => {
@@ -59,17 +57,6 @@ const NationalDebtHero = (): JSX.Element => {
         </div>
       )
       }
-      <div className={calloutContainer}>
-        <div className={heroImageCallout} data-testid={"nationalDebtCallout"}>
-          <FontAwesomeIcon icon={faFlagUsa} className={icon} />
-          <p>
-            This topic is the first of four U.S. government financial concepts from Your Guide to
-            America’s Finances with more being added in the coming months.
-            We’ll help you learn more about money coming in (Revenue), money going out (Spending),
-            and the <CustomLink url={'/americas-finance-guide/national-deficit/'}> Deficit </CustomLink> and Debt.
-          </p>
-        </div>
-      </div>
     </>
   );
 }

--- a/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
+++ b/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
@@ -1,10 +1,7 @@
 import React, {useEffect, useLayoutEffect, useState} from "react";
 import CustomLink from "../../../../components/links/custom-link/custom-link";
 import {
-  calloutContainer,
   counterSourceInfo,
-  heroImageCallout,
-  icon,
   footNotes,
   deficitBox,
   deficitBoxPercent,
@@ -14,7 +11,7 @@ import {
   deficit
 } from "../../hero-image/hero-image.module.scss"
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faFlagUsa, faDownLong, faUpLong} from "@fortawesome/free-solid-svg-icons";
+import { faDownLong, faUpLong} from "@fortawesome/free-solid-svg-icons";
 import {apiPrefix, basicFetch} from "../../../../utils/api-utils";
 import {numberWithCommas} from "../../../../helpers/simplify-number/simplifyNumber";
 import {pxToNumber} from "../../../../helpers/styles-helper/styles-helper";
@@ -134,9 +131,6 @@ const NationalDeficitHero = ({glossary}): JSX.Element => {
       Monthly Treasury Statement (MTS)
     </CustomLink>;
 
-  const debt = <CustomLink url={'/americas-finance-guide/national-debt/'}>Debt</CustomLink>;
-  const spending = <CustomLink url={'/americas-finance-guide/federal-spending/'}>Spending</CustomLink>
-
   const fiscalYear =
     <GlossaryTerm term={'fiscal year'} page={'Deficit Explainer'} glossary={glossary} >
       fiscal year (FY)
@@ -193,16 +187,6 @@ const NationalDeficitHero = ({glossary}): JSX.Element => {
           }
         <div className={deficitBoxPercent}>
           {deficitDifPercent}%
-        </div>
-      </div>
-      <div className={calloutContainer}>
-        <div className={heroImageCallout} data-testid={"nationalDebtCallout"}>
-          <FontAwesomeIcon icon={faFlagUsa} className={icon} />
-          <p>
-            This topic is the second of four U.S. government financial concepts from Your Guide to
-            America’s Finances with more being added in the coming months. We’ll help you learn more
-            about money coming in (Revenue), money going out ({spending}), and the Deficit and {debt}.
-          </p>
         </div>
       </div>
     </>


### PR DESCRIPTION
Code Coverage: 89.69

Removed Blurbs from debt, deficit, spending page.

Modify test to remove test

removed unused styling.