### PR TITLE
FDG-6112 AFG URL Redirects

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -183,6 +183,7 @@ module.exports = {
           default: require.resolve("./src/components/mdx/defaultLayout.jsx")
         }
       }
-    }
+    },
+    `gatsby-plugin-client-side-redirect`
   ],
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -311,7 +311,8 @@ exports.createSchemaCustomization = ({ actions }) => {
 };
 
 exports.createPages = async ({ graphql, actions, reporter }) => {
-  const { createPage } = actions;
+  const { createPage, createRedirect } = actions;
+
   const result = await graphql(`
     query {
       allDatasets
@@ -459,7 +460,6 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     }
   `);
 
-
   const glossaryData = result.data.allGlossaryCsv.glossaryCsv;
 
   result.data.allBlsPublicApiData.blsPublicApiData
@@ -573,6 +573,30 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       }
     });
   }
+  createRedirect(
+    {
+      fromPath: '/government-revenue/',
+      toPath: '/americas-finance-guide/government-revenue/',
+      isPermanent: true
+    });
+  createRedirect(
+    {
+      fromPath: '/federal-spending/',
+      toPath: '/americas-finance-guide/federal-spending/',
+      isPermanent: true
+    });
+  createRedirect(
+    {
+      fromPath: '/national-deficit/',
+      toPath: '/americas-finance-guide/national-deficit/',
+      isPermanent: true
+    });
+  createRedirect(
+    {
+      fromPath: '/national-debt/',
+      toPath: '/americas-finance-guide/national-debt/',
+      isPermanent: true
+    });
 };
 
 exports.onCreatePage = async ({ page, actions: { createPage } }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14944,6 +14944,26 @@
         "date-and-time": "^0.11.1"
       }
     },
+    "gatsby-plugin-client-side-redirect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-client-side-redirect/-/gatsby-plugin-client-side-redirect-1.1.0.tgz",
+      "integrity": "sha512-ox3QpfQynNmH4SgBedMxi9WdEFVI/fQep0cpAu5mPSIQElIJmy+TF5fDZc56Ra+cvr/dz45sw+tUzE41aMlLfw==",
+      "requires": {
+        "fs-extra": "^7.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
     "gatsby-plugin-dts-css-modules": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-dts-css-modules/-/gatsby-plugin-dts-css-modules-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "gatsby": "^3.10.1",
     "gatsby-env-variables": "^2.0.0",
     "gatsby-plugin-build-date": "^1.0.0",
+    "gatsby-plugin-client-side-redirect": "^1.1.0",
     "gatsby-plugin-exclude": "^1.0.2",
     "gatsby-plugin-google-analytics": "^3.10.0",
     "gatsby-plugin-html-attributes": "^1.0.5",


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-6112

Line coverage: 89.45%

For dev localhost testing: This adds a new packaged dependency which needs to be installed. To test, run `build-dev` (or `build-prod`), then `npm run serve`. The redirects will work at localhost:9000. For example, http://localhost:9000/national-debt/ should redirect to `http://localhost:9000/americas-finance-guide/national-debt/`