### PR TITLE
FDG-6174 Debt Explainer - quote box margin disappear

### DIFF
--- a/src/layouts/explainer/quote-box/quote-box.tsx
+++ b/src/layouts/explainer/quote-box/quote-box.tsx
@@ -11,15 +11,16 @@ import {
 type QuoteBoxProps = {
   icon: any,
   primaryColor: string,
-  secondaryColor: string
+  secondaryColor: string,
+  customTopMargin: string,
   children: any
 }
 
 const QuoteBox: FunctionComponent<QuoteBoxProps> = (
-  {icon, primaryColor, secondaryColor, children}) => {
+  {icon, primaryColor, secondaryColor, customTopMargin, children}) => {
   return (
     <>
-      <div className={iconContainer} data-testid="quote-box">
+      <div className={iconContainer} style={{marginTop: customTopMargin}} data-testid="quote-box">
         <div
           className={iconBackground}
           style={{

--- a/src/layouts/explainer/sections/federal-spending/overview/spending-overview.jsx
+++ b/src/layouts/explainer/sections/federal-spending/overview/spending-overview.jsx
@@ -172,6 +172,7 @@ export const SpendingOverview = ({ glossary }) => {
         icon={faFlagUsa}
         primaryColor={spendingExplainerSecondary}
         secondaryColor={spendingExplainerLightSecondary}
+        customTopMargin={'-1rem'}
       >
         <p>
           According to the Constitution’s Preamble, the purpose of the federal

--- a/src/layouts/explainer/sections/government-revenue/sources-of-federal-revenue/sources-of-federal-revenue.jsx
+++ b/src/layouts/explainer/sections/government-revenue/sources-of-federal-revenue/sources-of-federal-revenue.jsx
@@ -148,6 +148,7 @@ const SourcesOfFederalRevenue = ({ glossary }) => {
         icon={faMartiniGlassCitrus}
         primaryColor={revenueExplainerPrimary}
         secondaryColor={revenueExplainerLightSecondary}
+        customTopMargin={'-1rem'}
       >
         <p className={quoteBoxContent}>
           From 1868 until 1913, 90% of all federal revenue came from taxes on

--- a/src/layouts/explainer/sections/national-debt/national-debt.jsx
+++ b/src/layouts/explainer/sections/national-debt/national-debt.jsx
@@ -474,6 +474,7 @@ export const FundingProgramsSection = () => {
         icon={faFlagUsa}
         primaryColor={debtExplainerPrimary}
         secondaryColor={debtExplainerLightSecondary}
+        customTopMargin={'0'}
       >
         <p>
           In accordance with the 2014 DATA Act, federal agencies are required to submit financial


### PR DESCRIPTION
- Note: During my work I noticed every other quote box had incorrect top margin vs the mocks, so I readjusted those as well.
- I would encourage the reviewer to check the margin for the boxes vs the mocks to double to re affirm
- Coverage: 89.32%
- Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-6174