### PR TITLE
FDG-6196 AFG Explainer pages - Links issue on Explainer pages

### DIFF
--- a/src/layouts/explainer/sections/federal-spending/overview/spending-overview.jsx
+++ b/src/layouts/explainer/sections/federal-spending/overview/spending-overview.jsx
@@ -20,7 +20,7 @@ export const SpendingOverview = ({ glossary }) => {
   const [deficitTerm, setDeficitTerm] = useState(null);
 
   const deficit = (
-    <CustomLink url={"/national-deficit/"}>national deficit</CustomLink>
+    <CustomLink url={"/americas-finance-guide/national-deficit/"}>national deficit</CustomLink>
   )
   const usaSpending =
     <CustomLink url={'https://www.usaspending.gov/explorer'}>USAspending.gov</CustomLink>;

--- a/src/layouts/explainer/sections/government-revenue/sources-of-federal-revenue/sources-of-revenue-circle-chart/sources-of-revenue-circle-chart.jsx
+++ b/src/layouts/explainer/sections/government-revenue/sources-of-federal-revenue/sources-of-revenue-circle-chart/sources-of-revenue-circle-chart.jsx
@@ -190,7 +190,6 @@ const SourcesOfRevenueCircleChart = ({ width }) => {
         ...exciseTax,
         "percent": Number(exciseTax.value) / totalRev,
       });
-
       setChartData({children: data});
 
       if(chartAltText === ""){
@@ -210,21 +209,6 @@ const SourcesOfRevenueCircleChart = ({ width }) => {
     categoryData
   ]);
 
-  const chartWrap = useRef(null);
-
-  useEffect(() => {
-
-    const handleOutsideClick = (event) => {
-      if (chartWrap.current && !chartWrap.current.contains(event.target)) {
-        event.stopPropagation();
-        event.preventDefault();
-        HandleChartMouseLeave();
-      }
-    }
-    // Adding tap/click event listener
-    document.addEventListener("click", handleOutsideClick);
-    return () => document.removeEventListener("click", handleOutsideClick);
-  }, [chartWrap]);
 
 
   useEffect(() => {
@@ -316,7 +300,6 @@ const SourcesOfRevenueCircleChart = ({ width }) => {
               className={chartSize}
               onMouseLeave={HandleChartMouseLeave}
               onClick={HandleChartMouseLeave}
-              ref={chartWrap}
             >
               <CirclePacking
                 data={chartData}


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-6196

The deleted code was no longer necessary after some refactoring that happened in an earlier defect, and was the cause of external links not working  