### PR TITLE
FDG-5818 Design feedback

### DIFF
--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
@@ -154,8 +154,8 @@ const TotalSpendingChart = ({width}) => {
             width={ 550 }
             height={ 490 }
             margin={width < pxToNumber(breakpointLg) ?
-              {top: 25, right: 25, bottom: 45, left: 65} :
-              {top: 25, right: 25, bottom: 45, left: 50}
+              {top: 25, right: 25, bottom: 35, left: 65} :
+              {top: 25, right: 15, bottom: 45, left: 50}
             }
             enablePoints={true}
             pointSize={0}

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.module.scss
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.module.scss
@@ -43,7 +43,7 @@
         }
 
         .dataLabel {
-          color: #5b616b;
+          color: #666666;
           font-size: $font-size-14;
           font-weight: $semi-bold-weight;
           margin: 0 1.25rem;
@@ -53,6 +53,11 @@
   }
 }
 
+@media screen and (min-width: $breakpoint-lg - 1) {
+  :global(.chartContainerChart) {
+    max-width: 484px !important;
+  }
+}
 
 @media screen and (max-width: $breakpoint-lg - 1) {
   :global(.chartContainerFooter) {
@@ -64,7 +69,7 @@
   }
   :global(.chartContainerFooter) {
     p {
-      margin-top: 0;
+      margin-top: .75rem;
     }
   }
 


### PR DESCRIPTION
1. The width of the chart is more narrow than expected on desktop — can we widen the span of it to better match Zeplin?
2. There is a tighter gap than expected between the labels on the x-axis and the footer statement on mobile — can we review to make sure there’s a 1rem/16px spacing between them?
3. Curious to see if we can fit in a change with the type color of the headline labels: ‘Fiscal Year’, Total spending’, and ‘GDP’ — I overlooked the hex color and saw that it was not 666666 on my Zeplin mock :upside_down_face:, but if it can’t be included then we can address it later

https://federal-spending-transparency.atlassian.net/browse/FDG-5818

No change in coverage