### PR TITLE
FDG-5820 Fixed issue with checking BEA data results

### DIFF
--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
@@ -118,7 +118,7 @@ const TotalSpendingChart = ({ width, cpiDataByYear }) => {
           spendingMinYear = finalSpendingChartData[0].x;
           spendingMaxYear = finalSpendingChartData[finalSpendingChartData.length - 1].x;
           let spendingMaxAmount = Math.ceil(finalSpendingChartData[finalSpendingChartData.length - 1].y);
-
+          let lastUpdatedDateGDP = new Date();
           setMinYear(spendingMinYear);
           setMaxYear(spendingMaxYear);
 
@@ -127,12 +127,14 @@ const TotalSpendingChart = ({ width, cpiDataByYear }) => {
           //ToDo: This can be moved to a custom Hook, and since GDP data is updated monthly we can think about consuming a flat file via Gatsby     
           basicFetch(gdpEndPoint)
             .then((bea_res) => {
+              if(bea_res.BEAAPI.Results.Notes[0]){
+                let extractedDateGDP = bea_res.BEAAPI.Results.Notes[0]?.NoteText.slice(bea_res.BEAAPI.Results.Notes[0].NoteText.indexOf("LastRevised: "));
+                lastUpdatedDateGDP = extractedDateGDP ? new Date(extractedDateGDP) : new Date();
+              }
               if (bea_res.BEAAPI.Results.Data) {
                 let finalGDPChartData = [];
                 let total = 0;
                 let count= 0;
-                let extractedDateGDP = bea_res.BEAAPI.Results.Notes[0].NoteText.slice(bea_res.BEAAPI.Results.Notes[0].NoteText.indexOf("LastRevised: "));
-                let lastUpdatedDateGDP = extractedDateGDP ? new Date(extractedDateGDP) : new Date();
 
                 bea_res.BEAAPI.Results.Data
                   .map((entry) => {


### PR DESCRIPTION
CC: No Change

https://federal-spending-transparency.atlassian.net/browse/FDG-5820

Checking if BEA Notes is not null before extracting the date.