### PR TITLE
FDG-5849

### DIFF
--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.js
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.js
@@ -26,14 +26,6 @@ export const chartCopy = {
     "Line graph comparing the total federal spending to the total GDP dollar amount.",
 };
 
-const getFirstElPadding = (chartView, isMobileView) => {
-  if (chartView === "percentageGdp") {
-    if (isMobileView) return "112px";
-    return "112px";
-  }
-  return "16px";
-};
-
 export const dataHeader = chartToggleConfig => {
   if (!chartToggleConfig) return;
   const {
@@ -114,7 +106,8 @@ export const dataHeader = chartToggleConfig => {
           <div
             className={styles.dataElement}
             style={{
-              paddingLeft: getFirstElPadding(selectedChartView, isMobile),
+              paddingLeft:
+                selectedChartView === "percentageGdp" ? "112px" : "16px",
             }}
           >
             <div className={styles.dataValue}>2020</div>

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.js
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.js
@@ -51,11 +51,15 @@ export const dataHeader = chartToggleConfig => {
       style={{
         display: "flex",
         flexDirection: "column",
-        marginBottom: "0.75rem",
         justifyContent: "center",
       }}
     >
-      <div className={styles.chartToggle}>
+      <div
+        className={styles.chartToggle}
+        style={{
+          marginBottom: isMobile ? "0.75rem" : "1rem",
+        }}
+      >
         <button
           className={styles.toggleButton}
           style={{
@@ -161,7 +165,7 @@ const formatCurrency = v => {
 };
 
 const formatPercent = v => {
-  return `${v}%`
+  return `${v}%`;
 };
 
 const chartTheme = {

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.js
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.js
@@ -28,10 +28,10 @@ export const chartCopy = {
 
 const getFirstElPadding = (chartView, isMobileView) => {
   if (chartView === "percentageGdp") {
-    if (isMobileView) return "64px";
-    return "88px";
+    if (isMobileView) return "112px";
+    return "112px";
   }
-  return "0px";
+  return "16px";
 };
 
 export const dataHeader = chartToggleConfig => {
@@ -47,7 +47,9 @@ export const dataHeader = chartToggleConfig => {
       style={{
         display: "flex",
         flexDirection: "column",
-        width: isMobile ? "90%" : "inherit",
+        marginTop: "1rem",
+        marginBottom: "1rem",
+        justifyContent: "center",
       }}
     >
       <div className={styles.chartToggle}>
@@ -61,7 +63,8 @@ export const dataHeader = chartToggleConfig => {
             background:
               selectedChartView === "totalSpending" ? "#00766C" : "#f1f1f1",
             borderRight: "none",
-            width: "50%",
+            width: isMobile ? "144px" : "224px",
+            height: isMobile ? "1.5rem" : "2rem",
           }}
           onClick={() => {
             setSelectedChartView("totalSpending");
@@ -87,7 +90,8 @@ export const dataHeader = chartToggleConfig => {
               selectedChartView === "percentageGdp" ? "#f1f1f1" : "#00766C",
             background:
               selectedChartView === "percentageGdp" ? "#00766C" : "#f1f1f1",
-            width: "50%",
+            width: isMobile ? "144px" : "224px",
+            height: isMobile ? "1.5rem" : "2rem",
           }}
           onClick={() => {
             setSelectedChartView("percentageGdp");

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.js
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.js
@@ -26,6 +26,18 @@ export const chartCopy = {
     "Line graph comparing the total federal spending to the total GDP dollar amount.",
 };
 
+const getFirstElPadding = (chartView, isMobile) => {
+  if (chartView === "percentageGdp") {
+    return "112px";
+  }
+  if (chartView === "totalSpending") {
+    if (isMobile) {
+      return "52px";
+    }
+  }
+  return "32px";
+};
+
 export const dataHeader = chartToggleConfig => {
   if (!chartToggleConfig) return;
   const {
@@ -39,7 +51,7 @@ export const dataHeader = chartToggleConfig => {
       style={{
         display: "flex",
         flexDirection: "column",
-        marginTop: "1rem",
+        // marginTop: "1rem",
         marginBottom: "1rem",
         justifyContent: "center",
       }}
@@ -106,8 +118,7 @@ export const dataHeader = chartToggleConfig => {
           <div
             className={styles.dataElement}
             style={{
-              paddingLeft:
-                selectedChartView === "percentageGdp" ? "112px" : "16px",
+              paddingLeft: getFirstElPadding(selectedChartView, isMobile),
             }}
           >
             <div className={styles.dataValue}>2020</div>

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.js
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.js
@@ -51,8 +51,7 @@ export const dataHeader = chartToggleConfig => {
       style={{
         display: "flex",
         flexDirection: "column",
-        // marginTop: "1rem",
-        marginBottom: "1rem",
+        marginBottom: "0.75rem",
         justifyContent: "center",
       }}
     >

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
@@ -278,10 +278,15 @@ const TotalSpendingChart = ({ width, cpiDataByYear }) => {
     if (!selectedChartView) return;
     if (selectedChartView === "percentageGdp") {
       setChartData(percentageData);
-    } else {
+    }
+    if (
+      selectedChartView === "totalSpending" &&
+      gdpChartData.length &&
+      spendingChartData.length
+    ) {
       setChartData(totalData);
     }
-  }, [selectedChartView]);
+  }, [selectedChartView, gdpChartData, spendingChartData]);
 
   return (
     <>
@@ -294,6 +299,7 @@ const TotalSpendingChart = ({ width, cpiDataByYear }) => {
         <div className={visWithCallout}>
           <div className={container}>
             <ChartContainer
+              key={selectedChartView}
               title={chartCopy.title}
               subTitle={chartCopy.subtitle}
               footer={chartCopy.footer}

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
@@ -306,6 +306,7 @@ const TotalSpendingChart = ({ width, cpiDataByYear }) => {
               date={lastUpdatedDate}
               header={dataHeader(chartToggleConfig)}
               altText={chartCopy.altText}
+              customHeaderStyles={{ marginTop: "1rem", marginBottom: "0" }}
             >
               <div className={lineChart} data-testid={"chartParent"}>
                 <Line

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
@@ -299,7 +299,6 @@ const TotalSpendingChart = ({ width, cpiDataByYear }) => {
         <div className={visWithCallout}>
           <div className={container}>
             <ChartContainer
-              key={selectedChartView}
               title={chartCopy.title}
               subTitle={chartCopy.subtitle}
               footer={chartCopy.footer}

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
@@ -305,7 +305,7 @@ const TotalSpendingChart = ({ width, cpiDataByYear }) => {
               date={lastUpdatedDate}
               header={dataHeader(chartToggleConfig)}
               altText={chartCopy.altText}
-              customHeaderStyles={{ marginTop: "1rem", marginBottom: "0" }}
+              customHeaderStyles={{ marginTop: "0.5rem", marginBottom: "0" }}
             >
               <div className={lineChart} data-testid={"chartParent"}>
                 <Line

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.module.scss
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.module.scss
@@ -16,7 +16,6 @@
   .chartToggle {
     display: flex;
     width: 100%;
-    margin-bottom: 16px;
     border-radius: 8px;
     margin-top: 16px;
     justify-content: center;

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.module.scss
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.module.scss
@@ -19,6 +19,7 @@
     margin-bottom: 16px;
     border-radius: 8px;
     margin-top: 16px;
+    justify-content: center;
   }
 
   .toggleButton {


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-5849

design review feedback:

(a) Styling adjustments for desktop:

The toggle size is shorter than expected (should be 2rem/32px tall).

The toggle size is more narrow than expected (should be 9rem/144px wide in total).

(b) Styling adjustments for mobile:

The toggle size is taller than expected (should be 1.5rem/24px tall).

The toggle size is more narrow than expected (should be 28rem/448px wide in total).

The spacing above and below the toggle is greater than expected (should be 1 rem/16px above and below).
**mockups below**
desktop:
<img width="439" alt="2022-10-20_Spending_desktop" src="https://user-images.githubusercontent.com/111370583/197043612-46a0d832-61c5-4b09-86de-771496b1f40b.png">

mobile:
<img width="290" alt="2022-10-20_Spending_mobile" src="https://user-images.githubusercontent.com/111370583/197043735-d8c70bd9-6667-4f31-8e21-0ce18f9f407e.png">


