### PR TITLE
Attempt to fix test failures with longer timeouts

### DIFF
--- a/src/components/__build-tests__/postbuild-static-pages.ft.js
+++ b/src/components/__build-tests__/postbuild-static-pages.ft.js
@@ -25,7 +25,6 @@ const siteRoot = `http://localhost:${port}`;
 const datasetIdMap = require('../../transform/static-metadata/datasets.json');
 const apiMap = require('../../transform/endpointConfig')
   .getEndpointConfigsById(EXCLUDED_ENDPOINT_IDS, ADDITIONAL_ENDPOINTS);
-const { freshTopics } = require('../../transform/topics-config');
 const multimatch = require('multimatch');
 const recordSettingAuctionData = "015-BFS-2014Q1-14";
 
@@ -64,6 +63,8 @@ describe('Fully built site', () => {
 
     browser = await puppeteer.launch();
     page = await browser.newPage();
+
+    page.setDefaultTimeout(120000);
 
     await page.emulate({
       viewport: {
@@ -109,7 +110,7 @@ describe('Fully built site', () => {
     browser.close();
   });
 
-  it.skip('has all expected automatic pages from the pages directory', async () => {
+  it('has all expected automatic pages from the pages directory', async () => {
     const pagePaths = [
       '/',
       '/api-documentation',
@@ -121,13 +122,13 @@ describe('Fully built site', () => {
     for (const pagePath of pagePaths) {
       await verifyPageStatus(`${siteRoot}${pagePath === '/' ? pagePath : (pagePath + '/')}`);
     }
-  });
+  }, 240000);
 
-  it.skip('has a custom 404 page', async ()=> {
+  it('has a custom 404 page', async ()=> {
     await verifyPageStatus(`${siteRoot}/fake/`, 404);
-  });
+  }, 240000);
 
-  it.skip('ensures the date range shown on the dataset detail page for each dataset matches what ' +
+  it('ensures the date range shown on the dataset detail page for each dataset matches what ' +
     'comes back from the metadata API', async() => {
 
     const dateFormat = 'MM/dd/yyyy';
@@ -236,9 +237,9 @@ describe('Fully built site', () => {
         await ensureDateRange(dataset, normalDateDatasets[dataset].slug);
       }
     }
-  });
+  }, 360000);
 
-  it.skip('correctly includes or excludes preprod-only whitelisted datasets depending ' +
+  it('correctly includes or excludes preprod-only whitelisted datasets depending ' +
     'upon environment', async () => {
     if (ADDITIONAL_DATASETS && Object.keys(ADDITIONAL_DATASETS).length) {
       // todo - Update the following to be an "await Promise.all" as seen in the test below
@@ -251,13 +252,5 @@ describe('Fully built site', () => {
         }
       }
     }
-  });
-
-  it.skip('only builds the topics pages in preprod environments', async() => {
-    const pageStatus = (ENV_ID === 'preprod') ? 200 : 404;
-    const topics = Object.values(freshTopics);
-    for (const topic of topics) {
-      await verifyPageStatus(`${siteRoot}/topics/${topic.slug}/`, pageStatus);
-    }
-  });
+  }, 240000);
 });


### PR DESCRIPTION
Attempt to overcome post-build test failures by setting longer puppeteer page navigation timeouts and jest test timeouts.

Also, remove obsolete test for legacy "topic" pages.