### PR TITLE
FDG 5863 Spending Explainer - Add 'Percentage of GDP' section to the 'Government Spending and the U.S. Economy (GDP), FY YYYY-YYYY' line chart

### DIFF
--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
@@ -123,7 +123,7 @@ const TotalSpendingChart = ({ width, cpiDataByYear }) => {
     // which doesn't seem to happen naturally when nivo has a flex container
     const svgChart = document.querySelector('[data-testid="chartParent"] svg');
     if (svgChart) {
-      svgChart.setAttribute('viewBox', '0 0 550 490');
+      svgChart.setAttribute('viewBox', '0 0 550 400');
       svgChart.setAttribute('height', '100%');
       svgChart.setAttribute('width', '100%');
     }
@@ -344,11 +344,11 @@ const TotalSpendingChart = ({ width, cpiDataByYear }) => {
                   }}
                   colors={d => d.color}
                   width={550}
-                  height={446}
+                  height={400}
                   margin={
                     width < pxToNumber(breakpointLg)
-                      ? { top: 25, right: 25, bottom: 35, left: 55 }
-                      : { top: 25, right: 15, bottom: 45, left: 50 }
+                      ? { top: 25, right: 25, bottom: 30, left: 55 }
+                      : { top: 20, right: 15, bottom: 35, left: 50 }
                   }
                   enablePoints={true}
                   pointSize={0}

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
@@ -344,10 +344,10 @@ const TotalSpendingChart = ({ width, cpiDataByYear }) => {
                   }}
                   colors={d => d.color}
                   width={550}
-                  height={490}
+                  height={446}
                   margin={
                     width < pxToNumber(breakpointLg)
-                      ? { top: 25, right: 25, bottom: 35, left: 65 }
+                      ? { top: 25, right: 25, bottom: 35, left: 55 }
                       : { top: 25, right: 15, bottom: 45, left: 50 }
                   }
                   enablePoints={true}

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.module.scss
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.module.scss
@@ -94,7 +94,7 @@
         min-width: 400px;
 
         .dataElement:not(:last-child) {
-          padding-right: 1.25rem;
+          padding-right: 1rem;
         }
 
         .dataElement {


### PR DESCRIPTION
No change in coverage
Addresses design review: https://data-transparency-bfs.slack.com/archives/CRFQA2DM1/p1666799533530549
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-5863