### PR TITLE
FDG-6311 Deficit Explainer- hero section flip counter issue on mobile

### DIFF
--- a/src/layouts/explainer/heros/federal-spending/federal-spending-hero.tsx
+++ b/src/layouts/explainer/heros/federal-spending/federal-spending-hero.tsx
@@ -83,7 +83,7 @@ const FederalSpendingHero = (): JSX.Element => {
       <div className={counterContainerSpending}>
         <SplitFlapDisplay value={totalSpending}
                           minLength={17} // number of characters to initially display
-                          mobilePrecision={2}
+                          mobilePrecision={parseInt(totalSpending) > 999999999999 ? 2 : 0}
                           valueType="currency"
         />
       </div>

--- a/src/layouts/explainer/heros/government-revenue/government-revenue-hero.tsx
+++ b/src/layouts/explainer/heros/government-revenue/government-revenue-hero.tsx
@@ -95,7 +95,7 @@ const GovernmentRevenueHero = ({glossary}): JSX.Element => {
       <div className={flapWrapper}>
         <SplitFlapDisplay
           value={currentRevenue}
-          mobilePrecision={2}
+          mobilePrecision={parseInt(currentRevenue) > 999999999999 ? 2 : 0}
           minLength={17}
           valueType="currency"
         />

--- a/src/layouts/explainer/heros/national-debt/national-debt-hero.tsx
+++ b/src/layouts/explainer/heros/national-debt/national-debt-hero.tsx
@@ -46,7 +46,7 @@ const NationalDebtHero = (): JSX.Element => {
         <div className={counterContainer}>
           <SplitFlapDisplay value={nationalDebtValue}
                             minLength={18} // number of characters to initially display
-                            mobilePrecision={2}
+                            mobilePrecision={parseInt(nationalDebtValue) > 999999999999 ? 2 : 0}
                             valueType="currency"
           />
           <div className={counterSourceInfo}>

--- a/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
+++ b/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
@@ -161,7 +161,7 @@ const NationalDeficitHero = ({glossary}): JSX.Element => {
       </p>
       <div>
         <SplitFlapDisplay value={desktopDeficit}
-                          precision={0}
+                          precision={parseInt(desktopDeficit) > 999999999999 ? 2 : 0}
                           minLength={15} // number of characters to initially display
                           valueType="currency"
         />


### PR DESCRIPTION
CC: 89
https://federal-spending-transparency.atlassian.net/browse/FDG-6311

Added logic to pass precision of 2 if deficit was greater than 999,999,999,999.

Passes all tests locally.
Builds locally.
