### PR TITLE
FDG-6057 Update from design review

### DIFF
--- a/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/federal-revenue-trends-and-us-economy.jsx
+++ b/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/federal-revenue-trends-and-us-economy.jsx
@@ -11,7 +11,7 @@ const FederalRevenueTrendsAndUSEconomy = () => {
           Coming Soon: A section exploring how revenue trends relate to the U.S.
           economy.
         </p>
-      <Experimental featureId={'revenue-trends-section'} exclude={true}>
+      <Experimental featureId={'revenue-trends-section'} >
         <TotalRevenueChart />
       </Experimental>
     </div>

--- a/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.jsx
+++ b/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.jsx
@@ -298,7 +298,7 @@ const TotalRevenueChart = ({ width }) => {
                 animate={false}
                 tooltip={() => null}
                 markers={getMarkers(width, selectedChartView)}
-              ></Line>
+              />
             </div>
           </ChartContainer>
         </div>

--- a/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.module.scss
+++ b/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.module.scss
@@ -3,6 +3,7 @@
 :global(.chartContainerHeader) {
   font-size: $font-size-14 !important;
   align-items: center;
+  margin-top: 1rem;
 }
 
 .container {
@@ -77,6 +78,10 @@
 }
 
 @media screen and (max-width: $breakpoint-lg - 1) {
+  :global(.chartContainerHeader) {
+    margin-top: .125rem;
+  }
+
   :global(.chartContainerFooter) {
     font-size: $font-size-14 !important;
   }


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-6057
no change in coverage 

Design Review:
Some design spacing adjustments needed for the toggle placement, since it is wider than expected:
Desktop: The spacing between the copy and the top of the toggle should be 2rem/32px.
Mobile: The spacing between the copy and the top of the toggle is 1rem/16px.

![image](https://user-images.githubusercontent.com/77741207/199849231-54732f3a-7c5a-4e7c-b92a-e45b7ada3627.png)
![image](https://user-images.githubusercontent.com/77741207/199849530-4734ae64-d816-428f-84e9-775499da9b61.png)
