### PR TITLE
FDG-6157 Whitelist reports for Daily Treasury Statement

### DIFF
--- a/src/components/published-reports/filter-section/filter-section.jsx
+++ b/src/components/published-reports/filter-section/filter-section.jsx
@@ -59,7 +59,7 @@ export const FilterSection = ({ reports, setSelectedFile, reportsTip }) => {
   };
 
   const populateDays = () => {
-    if (selectedReportGroup?.value) {
+    if (selectedReportGroup?.value && selectedYear?.value && selectedMonth?.value) {
       const filteredReports = selectedReportGroup.value
         .filter(r => r.report_date.getFullYear() === selectedYear.value &&
           (r.report_date.getMonth()) === selectedMonth.value);
@@ -180,12 +180,14 @@ export const FilterSection = ({ reports, setSelectedFile, reportsTip }) => {
    * months in the dropdowns and assess if we can use the same selected year/month with the
    *  newest selected report group.
    */
-  const recalibrateYM = (reportVal) => {
+  const recalibrateYMD = (reportVal) => {
     const availableYears = populateYears(reportVal);
     const selectedYearValue = selectedYear ? selectedYear.value : null;
     const selectedMonthValue = selectedMonth ? selectedMonth.value : null;
+    const selectedDayValue = selectedDay ? selectedDay.value : null;
     let isSelectedYearValid = false;
     let isSelectedMonthValid = false;
+    let isSelectedDayValid = false;
 
     // Check to see if a year is selected in the dropdown
     if (selectedYearValue) {
@@ -199,6 +201,12 @@ export const FilterSection = ({ reports, setSelectedFile, reportsTip }) => {
         if (selectedMonthValue) {
           // Check to see if the selected month matches an available month in the new report group
           isSelectedMonthValid = availableMonths.some(r => r.value === selectedMonthValue);
+
+          if (isSelectedMonthValid && selectedReportGroup.daily) {
+            const availableDays = populateDays();
+            isSelectedDayValid = availableDays?.length &&
+              availableDays.some(r => r.value === selectedDayValue);
+          }
         }
       }
     }
@@ -207,6 +215,9 @@ export const FilterSection = ({ reports, setSelectedFile, reportsTip }) => {
     }
     if (!isSelectedMonthValid) {
       setSelectedMonth(null);
+    }
+    if (!isSelectedDayValid) {
+      setSelectedDay(null);
     }
   };
 
@@ -267,7 +278,7 @@ export const FilterSection = ({ reports, setSelectedFile, reportsTip }) => {
             reportGroup.id === selectedReportGroup.id
         );
       previousSelectedGroupId.current = selectedReportGroup.id;
-      recalibrateYM(selectedReportGroup.value);
+      recalibrateYMD(selectedReportGroup.value);
       smartLoadFile(newSelectedGroup);
     }
   }, [selectedReportGroup]);
@@ -373,7 +384,7 @@ export const FilterSection = ({ reports, setSelectedFile, reportsTip }) => {
               />
             </div>
           )}
-          {reportsByDay.length > 0 && (
+          {(reportsByDay.length > 0 && selectedReportGroup.daily) && (
             <div data-testid="day-wrapper" className={selectWrapper}>
               <SelectControl changeHandler={setSelectedDay}
                              label={dayLabel}

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -46,7 +46,8 @@ const globalConstants = {
        * to ES6 module syntax from CommonJS
        */
       datasets: ["015-BFS-2014Q1-13", "015-BFS-2014Q3-076", "015-BFS-2014Q1-11",
-        "015-BFS-2014Q1-07", "015-BFS-2014Q3-077", "015-BFS-2014Q1-18", "015-BFS-2014Q3-038"]
+        "015-BFS-2014Q1-07", "015-BFS-2014Q3-077", "015-BFS-2014Q1-18", "015-BFS-2014Q3-038",
+        "015-BFS-2014Q1-03"]
     },
     downloadService: {
       localStorageKeys: {

--- a/src/helpers/published-reports/published-reports.js
+++ b/src/helpers/published-reports/published-reports.js
@@ -17,7 +17,8 @@ const { getDateWithoutTimeZoneAdjust } = require ("../../utils/date-utils");
   * @type {string[]}
  */
 const whitelistDatasetIds = ["015-BFS-2014Q1-13", "015-BFS-2014Q3-076", "015-BFS-2014Q1-11",
-  "015-BFS-2014Q1-07", "015-BFS-2014Q3-077", "015-BFS-2014Q1-18", "015-BFS-2014Q3-038"];
+  "015-BFS-2014Q1-07", "015-BFS-2014Q3-077", "015-BFS-2014Q1-18", "015-BFS-2014Q3-038",
+  "015-BFS-2014Q1-03"];
 exports.whiteListIds = whitelistDatasetIds;
 
 const whitelistedGroupsByDataset = {};

--- a/src/transform/metadata-transform.js
+++ b/src/transform/metadata-transform.js
@@ -281,7 +281,9 @@ const extractPublishedReportsType = function(reports){
  */
 const datasetPublishedReportsCustomSelectionTips = {
   '015-BFS-2014Q1-13': 'Monthly Treasury Statement reports dated before 1998 are grouped ' +
-    'by year. Once inside the desired year, scroll to the specific month.'
+    'by year. Once inside the desired year, scroll to the specific month.',
+  '015-BFS-2014Q1-03': 'Daily Treasury Statement reports dated before FY 1998 are grouped ' +
+    'by year. Once inside the desired year, scroll to the specific month and day.'
 };
 
 const determineSEO = (dataset, mappedDataset) => {


### PR DESCRIPTION
Add text tip following the pattern of MTS reports explaining that older reports are aggregated into annual files. Update logic for switching from non-daily to daily type reports.

https://federal-spending-transparency.atlassian.net/browse/FDG-6157

Line coverage: 88.96%