### PR TITLE
FDG-6415 Missing Data visualization alt text – Percentage of GDP view

### DIFF
--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.js
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.js
@@ -20,13 +20,13 @@ const footer = (
 
 
 
-export const getChartCopy = (minYear, maxYear) => {
+export const getChartCopy = (minYear, maxYear, selectedChartView) => {
   return {
   title: `Government Spending and the U.S. Economy (GDP), FY ${minYear} – ${maxYear}`,
   subtitle: `Inflation Adjusted - ${maxYear} Dollars`,
   footer: footer,
-  altText:
-    "Line graph comparing the total federal spending to the total GDP dollar amount.",
+  altText: (selectedChartView === "percentageGdp" ? "A line graph showing the percentage of GDP." :
+    "Line graph comparing the total federal spending to the total GDP dollar amount."),
   }
 };
 

--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart.jsx
@@ -376,8 +376,7 @@ const TotalSpendingChart = ({ width, cpiDataByYear }) => {
     }
   }
 
-  const {title: chartTitle, subtitle: chartSubtitle, footer: chartFooter, altTex: chartAltText} = getChartCopy(minYear, maxYear);
-
+  const {title: chartTitle, subtitle: chartSubtitle, footer: chartFooter, altText: chartAltText} = getChartCopy(minYear, maxYear, selectedChartView);
   return (
     <>
       {isLoading && (

--- a/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart-helper.js
+++ b/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart-helper.js
@@ -31,14 +31,15 @@ const footer = (
   </p>
 );
 
-export const getChartCopy = (minYear, maxYear) => {
+export const getChartCopy = (minYear, maxYear, selectedChartView) => {
   return {
   title: `Federal Revenue and the U.S. Economy (GDP), FY ${minYear} – ${maxYear}`,
   subtitle: `Inflation Adjusted - ${maxYear} Dollars`,
   footer: footer,
-  altText:
-    'Line graph comparing the total federal revenue to the total GDP dollar amount.',
+  altText: (selectedChartView === "percentageGdp" ? "Line graph showing revenue as a percentage of GDP." :
+    'Line graph comparing the total federal revenue to the total GDP dollar amount.'),
   }
+  
 };
 
 export const dataHeader = (chartToggleConfig, headingValues) => {

--- a/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.jsx
+++ b/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.jsx
@@ -307,8 +307,8 @@ const TotalRevenueChart = ({ cpiDataByYear, width, beaGDPData }) => {
     title: chartTitle,
     subtitle: chartSubtitle,
     footer: chartFooter,
-    altTex: chartAltText,
-  } = getChartCopy(minYear, maxYear);
+    altText: chartAltText,
+  } = getChartCopy(minYear, maxYear, selectedChartView);
 
   return (
     <>


### PR DESCRIPTION
CC: No change

https://federal-spending-transparency.atlassian.net/browse/FDG-6415

Added logic for switching alt text depending on toggle view for both Spending and Revenue Chart.


Builds locally
Passes all tests locally