### PR TITLE
FDG-5495 GA Event Tracking - Accordions

### DIFF
--- a/src/components/accordion/accordion.jsx
+++ b/src/components/accordion/accordion.jsx
@@ -22,13 +22,14 @@ const Accordion = ({
   children,
   openEventNumber,
   closeEventNumber,
+  explainerGAEvent,
   dynamicGaEventValue,
 }) => {
   const [open, setOpen] = useState(defaultOpen || false);
   const [gaEventHandler, setgaEventHandler] = useState(null);
 
-  const gaEventOpen = useGAEventTracking(openEventNumber,"Debt");
-  const gaEventClose = useGAEventTracking(closeEventNumber,"Debt");
+  const gaEventOpen = useGAEventTracking(openEventNumber,explainerGAEvent);
+  const gaEventClose = useGAEventTracking(closeEventNumber,explainerGAEvent);
   
   const triggerGAEvent = (isOpen) => {
     if(gaEventOpen || gaEventClose){

--- a/src/layouts/explainer/data-sources-methodologies/data-sources-methodologies.tsx
+++ b/src/layouts/explainer/data-sources-methodologies/data-sources-methodologies.tsx
@@ -17,8 +17,8 @@ const analyticsEventMap: Record<
     explainerGAEvent: "Debt"
   },
   "national-deficit": {
-    openEventNumber: "27",
-    closeEventNumber: "28",
+    openEventNumber: "26",
+    closeEventNumber: "27",
     explainerGAEvent: "Deficit"
   },
 };

--- a/src/layouts/explainer/data-sources-methodologies/data-sources-methodologies.tsx
+++ b/src/layouts/explainer/data-sources-methodologies/data-sources-methodologies.tsx
@@ -9,11 +9,17 @@ type DsmProps = {
 
 const analyticsEventMap: Record<
   string,
-  { openEventNumber: string; closeEventNumber: string }
+  { openEventNumber: string; closeEventNumber: string; explainerGAEvent: string }
 > = {
   "national-debt": {
     openEventNumber: "40",
     closeEventNumber: "41",
+    explainerGAEvent: "Debt"
+  },
+  "national-deficit": {
+    openEventNumber: "27",
+    closeEventNumber: "28",
+    explainerGAEvent: "Deficit"
   },
 };
 

--- a/src/layouts/explainer/sections/national-debt/national-debt.jsx
+++ b/src/layouts/explainer/sections/national-debt/national-debt.jsx
@@ -461,6 +461,7 @@ export const FundingProgramsSection = () => {
           containerClass={fundingProgramAccordion}
           openEventNumber={"11"}
           closeEventNumber={"12"}
+          explainerGAEvent="Debt"
         >
           <div className={spendingCategoriesAccordionContent}>
             <p>
@@ -643,6 +644,7 @@ export const VisualizingTheDebtAccordion = ({ width }) => {
         openEventNumber={"20"}
         closeEventNumber={"21"}
         dynamicGaEventValue={dynamicGaEventValue}
+        explainerGAEvent="Debt"
       >
         <div className={accordionHeader}>
           <p>If this is 1 billion:</p>
@@ -2035,6 +2037,7 @@ export const DebtBreakdownSection = withWindowSize(
                 title="Why can't the government just print more money?"
                 openEventNumber={"26"}
                 closeEventNumber={"27"}
+                explainerGAEvent="Debt"
               >
                 While the Treasury prints actual dollar bills, “printing money”
                 is also a term that is sometimes used to describe a means of{" "}
@@ -2088,6 +2091,7 @@ export const DebtCeilingSection = () => (
         containerClass={debtCeilingAccordion}
         openEventNumber="28"
         closeEventNumber="29"
+        explainerGAEvent="Debt"
       >
         Government shutdowns occur when annual funding for ongoing federal
         government operations expires, and Congress does not renew it in time.

--- a/src/layouts/explainer/sections/national-deficit/debt-deficit-difference/debt-deficit-difference.jsx
+++ b/src/layouts/explainer/sections/national-deficit/debt-deficit-difference/debt-deficit-difference.jsx
@@ -55,8 +55,11 @@ export const DebtDeficitDifference = ({width}) => {
             title="How else does the federal government finance a deficit?"
             altStyleAccordion={{
               borderColor: deficitExplainerPrimary,
-              borderWidth: '1px'
+              borderWidth: '1px'          
             }}
+            openEventNumber={"15"}
+            closeEventNumber={"16"}
+            explainerGAEvent="Deficit"
           >
             The government also uses operating cash available from an account at the Federal
             Reserve to pay for the deficit. This would be similar to a business using a line of


### PR DESCRIPTION
CC: 89.19

https://federal-spending-transparency.atlassian.net/browse/FDG-5495

Added logic to Accordion Component to determine which explainer page the GA event should be tied to.

Builds locally
Passes all tests locally