### PR TITLE
FDG-6520 Update environment mappings

### DIFF
--- a/env/dev.js
+++ b/env/dev.js
@@ -1,8 +1,9 @@
 module.exports = {
   ENV_ID: 'dev',
-  API_BASE_URL: 'https://api.fiscaldata.treasury.gov',
-  DATA_DOWNLOAD_BASE_URL: 'https://fiscaldata.treasury.gov',
-  WEB_SOCKET_BASE_URL: 'wss://downloads.fiscaldata.treasury.gov/main',
+  API_BASE_URL: 'https://api.dev.fiscaldata.treasury.gov',
+  AUTHENTICATE_API: true,
+  DATA_DOWNLOAD_BASE_URL: 'https://dev.fiscaldata.treasury.gov',
+  WEB_SOCKET_BASE_URL: 'wss://downloads.dev.fiscaldata.treasury.gov/main',
   EXPERIMENTAL_WHITELIST: ['experimental-page', 'not-found-md', 'apiNKL', 'aboutUsMDX',
     'spending-trends-chart', 'revenue-trends-section'],
   ADDITIONAL_DATASETS: {},

--- a/env/stg.js
+++ b/env/stg.js
@@ -1,9 +1,9 @@
 module.exports = {
   ENV_ID: 'stg',
   // Api data in staging is incomplete and will throw page breaking errors on our site
-  API_BASE_URL: 'https://api.fiscaldata.treasury.gov',
-  DATA_DOWNLOAD_BASE_URL: 'https://fiscaldata.treasury.gov',
+  API_BASE_URL: 'https://api.stg.fiscaldata.treasury.gov',
+  DATA_DOWNLOAD_BASE_URL: 'https://stg.fiscaldata.treasury.gov',
+  WEB_SOCKET_BASE_URL: 'wss://downloads.stg.fiscaldata.treasury.gov/main',
   EXPERIMENTAL_WHITELIST: ['experimental-page'],
-  WEB_SOCKET_BASE_URL: 'wss://downloads.fiscaldata.treasury.gov/main',
   EXCLUDED_PAGE_PATHS: []
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build": "cross-env BUILD_ENV=prod gatsby build",
-    "develop": "cross-env BUILD_ENV=prod gatsby develop",
+    "develop-prod": "cross-env BUILD_ENV=prod gatsby develop",
     "develop-dev": "cross-env BUILD_ENV=dev gatsby develop",
     "develop-qat": "cross-env BUILD_ENV=qat gatsby develop",
     "develop-stg": "cross-env BUILD_ENV=stg gatsby develop",


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-6520

Configuration change only.
Only dev and stg envs needed changes. UAT already points to UAT backend. QAT is a front-end development sandbox and tentatively continues to point at DEV backend as before.  Prod remains unchanged.