### PR TITLE
FDG-6374 Update styling per design review

### DIFF
--- a/src/components/topics-section/homepage-tile/homepage-tile.jsx
+++ b/src/components/topics-section/homepage-tile/homepage-tile.jsx
@@ -20,7 +20,7 @@ const HomePageTile = ({
   width,
   customStyles,
   layout,
-  hasMobileImage,  
+  hasMobileImage
 }) => {
   let desktopImage, mobileImage;
   if (images) {
@@ -33,10 +33,9 @@ const HomePageTile = ({
   }
 
   const afgBookIconSource = '/images/AFG-icon.svg';
-  
 
   const isDesktop = width >= pxToNumber(breakpointLg);
-  // over write desktop-first styles with mobile-first styles, if we actually have a mobile imgage
+  // overwrite desktop-first styles with mobile-first styles, if we actually have a mobile image
   const isMobile = hasMobileImage
     ? width <= pxToNumber(breakpointSm)
     : width <= pxToNumber(breakpointLg);
@@ -110,25 +109,17 @@ const HomePageTile = ({
       <div className={mainContent} data-testid="tile">
         <div style={imageContainerStyle}>{isMobile ? mobile : desktop}</div>
         <div className={content.path ? undefined : comingSoon}>
-          <Grid container spacing={2}
-            alignItems="center">
-            {content.mainFeature && (
-              <Grid item xs={isMobile ? 2 : 1}>
-                <img
-                  src={afgBookIconSource}
-                  alt="An open book with a coin above the pages"
-                  className={afgBookIcon}
-                  data-testid={'afgBookIcon'}
-                />
-              </Grid>
-            )}
-            <Grid item xs={isMobile ? 10 : 11}>
               <h5 className={content.mainFeature ? mainTitle : secondaryTitle}>
+                {content.mainFeature && (
+                  <img
+                    src={afgBookIconSource}
+                    alt="An open book with a coin above the pages"
+                    className={afgBookIcon}
+                    data-testid={'afgBookIcon'}
+                  />
+                )}
                 <span>{content.title}</span>
               </h5>
-            </Grid>
-          </Grid>
-
           <div style={{ ...(customStyles?.body || {}) }}>
             {content.bodyGenerator ? content.bodyGenerator() : content.body}
           </div>

--- a/src/components/topics-section/homepage-tile/homepage-tile.module.scss
+++ b/src/components/topics-section/homepage-tile/homepage-tile.module.scss
@@ -5,7 +5,6 @@ $main-feature-body: $font-size-16;
 $secondary-feature-title: $font-size-24;
 $secondary-feature-body: $font-size-16;
 
-
 .mainContent {
   color: #666666;
   h5 {
@@ -26,6 +25,10 @@ $secondary-feature-body: $font-size-16;
     }
   }
 
+  p {
+    margin: 0;
+  }
+
   .comingSoon {
     width: 98.75%;
     margin-left: auto;
@@ -38,8 +41,7 @@ $secondary-feature-body: $font-size-16;
 
   .afgBookIcon{
     width: 3rem;
-    height: 2rem;
-    padding: 0 .5rem 0 0; 
+    padding: 0 .5rem 0.2rem 0;
     vertical-align: text-bottom;
   }
 }

--- a/src/components/topics-section/homepage-tile/homepage-tile.spec.js
+++ b/src/components/topics-section/homepage-tile/homepage-tile.spec.js
@@ -114,6 +114,29 @@ describe('Explainer Tile', () => {
     expect(tileLink).not.toBeInTheDocument();
   });
 
+  it('adds an AFG icon if the content is the main feature', () => {
+    const { getByTestId } = render(
+      <ExplainerTile
+        content={testTiles['pageName']}
+        images={''}
+        width={'1200'}
+      />
+    );
+
+    expect(getByTestId('afgBookIcon')).toBeInTheDocument();
+  });
+
+  it('does not add an AFG icon if the content is not the main feature', () => {
+    const { queryByTestId} = render(
+      <ExplainerTile
+        content={testTiles['anotherPage']}
+        images={''}
+        width={'1200'}
+      />
+    );
+    expect(queryByTestId('afgBookIcon')).not.toBeInTheDocument();
+  });
+
   it('renders the tile images with the provided alternate text', () => {
     const { getByRole } = render(
       <ExplainerTile

--- a/src/components/topics-section/topics-section.module.scss
+++ b/src/components/topics-section/topics-section.module.scss
@@ -10,7 +10,7 @@ $max-img-width-desktop: 771.5px;
     color: #555555;
     font-size: $font-size-16;
     font-weight: $semi-bold-weight;
-    margin-bottom: .5rem;  
+    margin-bottom: .5rem;
   }
   .tileContainer {
     margin-top: .5rem;
@@ -32,6 +32,7 @@ $max-img-width-desktop: 771.5px;
 
 @media screen and (min-width: $breakpoint-lg) {
   .topicsSectionContainer {
+    padding: 0 0 5rem;
     margin-top: 1rem;
   }
 


### PR DESCRIPTION
1. Change styling around AFG logo so it appears correctly spaced in relation to header and maintains natural aspect ratio

2. remove paragraph spacing after main content feature tile to ensure consistent tile spacing

3. Increase spacing above dataset search link to match zeplin desktop-width mock, which is set to 81px/~5rem (not 4 rem as misstated in Bonnie's slack notes).

4. Add unit tests for the AFG logo icon.

line cov in branch: 89.58%