### PR TITLE
FDG-5917 Add tool tips to the 'compared to...' pills on select explainer pages

### DIFF
--- a/src/layouts/explainer/heros/federal-spending/federal-spending-hero.tsx
+++ b/src/layouts/explainer/heros/federal-spending/federal-spending-hero.tsx
@@ -74,7 +74,7 @@ const FederalSpendingHero = (): JSX.Element => {
       });
   };
 
-  const rightTooltipText = 'The percentage change in spending compared to the same period last year in trillions $USD';
+  const rightTooltipText = 'The percentage change in spending compared to the same period last year.';
 
   useEffect(() => {
     getHeroData(spendingUrl);
@@ -109,7 +109,7 @@ const FederalSpendingHero = (): JSX.Element => {
           </p>
           {getPillData(spendingChange, spendingPercentChange, spendingChangeLabel,
             true, spendingExplainerPrimary+"25",
-            `The total amount spending has ${spendingChangeLabel} compared to the same period last year, in trillions $USD`,
+            `The total amount spending has ${spendingChangeLabel} compared to the same period last year.`,
             rightTooltipText)}
         </div>
       </div>

--- a/src/layouts/explainer/heros/government-revenue/government-revenue-hero.tsx
+++ b/src/layouts/explainer/heros/government-revenue/government-revenue-hero.tsx
@@ -86,9 +86,9 @@ const GovernmentRevenueHero = ({glossary}): JSX.Element => {
   );
 
   const rightTooltip =
-    'The percentage change in revenue compared to the same period last year, in trillions $USD';
+    'The percentage change in revenue compared to the same period last year.';
   const leftTooltip = (change) =>
-    `The total amount revenue has ${change} compared to the same period last year, in trillions $USD.`;
+    `The total amount revenue has ${change} compared to the same period last year.`;
 
   return (
     <>

--- a/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
+++ b/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
@@ -24,7 +24,7 @@ const NationalDeficitHero = ({glossary}): JSX.Element => {
 
   const deficitPillColor = '#b3532d1a';
 
-  const rightPillTooltipHoverText = 'The percentage change in the deficit compared to the same period last year, in trillions $USD.';
+  const rightPillTooltipHoverText = 'The percentage change in the deficit compared to the same period last year.';
 
 
   const [textCurrentDeficit, setTextCurrentDeficit] = useState<string | null>(null);
@@ -139,7 +139,7 @@ const NationalDeficitHero = ({glossary}): JSX.Element => {
       <div className={deficitBoxContainer}>
         {
           getPillData(deficitDifPill, deficitDifPercent, deficitStatus, true, deficitPillColor,
-          `The total amount the deficit has ${deficitStatus} compared to the same period last year, in trillions $USD.`,
+          `The total amount the deficit has ${deficitStatus} compared to the same period last year.`,
             rightPillTooltipHoverText)
         }
       </div>


### PR DESCRIPTION
Removed 'in trillions USD.' per data review
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-5917
No change in coverage