### PR TITLE
FDG-6741 Make Deficit Trends Bar Chart last bar coloring dynamic

### DIFF
--- a/src/layouts/explainer/explainer-components/chart-container/chart-container.module.scss
+++ b/src/layouts/explainer/explainer-components/chart-container/chart-container.module.scss
@@ -35,8 +35,8 @@
 .headerContainer {
   display: flex;
   justify-content: center;
-  gap: 1rem;
-  margin-bottom: 2rem;
+  gap: 5rem;
+  //margin-bottom: 2rem;
 
   div {
     text-align: center;

--- a/src/layouts/explainer/explainer-components/chart-container/chart-container.module.scss
+++ b/src/layouts/explainer/explainer-components/chart-container/chart-container.module.scss
@@ -36,7 +36,6 @@
   display: flex;
   justify-content: center;
   gap: 5rem;
-  //margin-bottom: 2rem;
 
   div {
     text-align: center;

--- a/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.module.scss
+++ b/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.module.scss
@@ -1,11 +1,5 @@
 @import "src/variables.module";
 
-:global(.chartContainerHeader) {
-  font-size: $font-size-14 !important;
-  align-items: center;
-  margin-top: 1rem;
-}
-
 .container {
   overflow: hidden;
 

--- a/src/layouts/explainer/sections/government-revenue/sources-of-federal-revenue/sources-of-revenue-circle-chart/sources-of-revenue-circle-chart.module.scss
+++ b/src/layouts/explainer/sections/government-revenue/sources-of-federal-revenue/sources-of-revenue-circle-chart/sources-of-revenue-circle-chart.module.scss
@@ -1,12 +1,9 @@
 @import "src/variables.module";
 
-:global(.chartContainerHeader) {
-  margin-top: 1.625rem;
-}
-
 .dataHeaderContainer {
   display: flex;
   flex-direction: column;
+  margin-top: 0.625rem;
 
   .header {
     font-size: $font-size-24;

--- a/src/layouts/explainer/sections/national-deficit/deficit-by-year/deficit-trends-bar-chart/deficit-trends-bar-chart.jsx
+++ b/src/layouts/explainer/sections/national-deficit/deficit-by-year/deficit-trends-bar-chart/deficit-trends-bar-chart.jsx
@@ -68,8 +68,9 @@ export const DeficitTrendsBarChart = ({ width }) => {
     let barCounter = 14;
     basicFetch(`${apiPrefix}${endpointUrl}`)
     .then((result) => {
+      const lastEntry = result.data[result.data.length - 1];
       result.data.forEach((entry) => {
-        if(entry.record_fiscal_year === '2022') {
+        if(entry.record_fiscal_year === lastEntry.record_fiscal_year) {
           apiData.push({
             "year": entry.record_fiscal_year,
             "deficit": (Math.abs(parseFloat(entry.current_fytd_net_outly_amt)) / 1000000000000).toFixed(2),
@@ -131,9 +132,9 @@ export const DeficitTrendsBarChart = ({ width }) => {
       else {
         const parentG = event.target.parentNode;
         const realBar = barSVGs.find((element) => element === parentG);
-        const indexOfRealBar = barSVGs.indexOf(realBar) - 22;
+        const indexOfRealBar = barSVGs.indexOf(realBar) - numOfBars;
         event.target.parentNode.parentNode.children[indexOfRealBar].firstChild.style.fill = barHighlightColor;
-        event.target.parentNode.parentNode.children[(barSVGs.length - 1) - 22].firstChild.style.fill = deficitExplainerPrimary;
+        event.target.parentNode.parentNode.children[(barSVGs.length - 1) - numOfBars].firstChild.style.fill = deficitExplainerPrimary;
         const matchedBar = chartData.find((element) => element.year === data.data.year);
         setHeaderYear(matchedBar.year);
         setHeaderDeficit(matchedBar.deficit);
@@ -149,7 +150,7 @@ export const DeficitTrendsBarChart = ({ width }) => {
       const parentG = event.target.parentNode;
       const barSVGs = Array.from(event.target.parentNode.parentNode.children);
       const realBar = barSVGs.find((element) => element === parentG);
-      const indexOfRealBar = barSVGs.indexOf(realBar) - 22;
+      const indexOfRealBar = barSVGs.indexOf(realBar) - numOfBars;
       event.target.parentNode.parentNode.children[indexOfRealBar].firstChild.style.fill = deficitExplainerPrimary;
     }
   }

--- a/src/layouts/explainer/sections/national-deficit/deficit-by-year/deficit-trends-bar-chart/deficit-trends-bar-chart.jsx
+++ b/src/layouts/explainer/sections/national-deficit/deficit-by-year/deficit-trends-bar-chart/deficit-trends-bar-chart.jsx
@@ -32,7 +32,6 @@ export const DeficitTrendsBarChart = ({ width }) => {
   const [minValue, setMinValue] = useState('');
   const [headerYear, setHeaderYear] = useState('');
   const [headerDeficit, setHeaderDeficit] = useState('');
-  const [gaChartTime, setGaChartTime] = useState(0);
   const [lastBar, setLastBar] = useState();
   const [numOfBars, setNumOfBars] = useState(0);
 
@@ -58,10 +57,6 @@ export const DeficitTrendsBarChart = ({ width }) => {
     }
   };
 
-  const calcDeficit = (value) => {
-    if(value.toString().split(".")[1].length < 2) {}
-  }
-
   const getChartData = () => {
     const apiData = [];
     // Counts pre api data bars
@@ -73,23 +68,28 @@ export const DeficitTrendsBarChart = ({ width }) => {
         if(entry.record_fiscal_year === lastEntry.record_fiscal_year) {
           apiData.push({
             "year": entry.record_fiscal_year,
-            "deficit": (Math.abs(parseFloat(entry.current_fytd_net_outly_amt)) / 1000000000000).toFixed(2),
+            "deficit": (Math.abs(parseFloat(entry.current_fytd_net_outly_amt))
+              / 1000000000000).toFixed(2),
             "deficitColor": barHighlightColor,
-            "decoyDeficit": ((3.5 - Math.abs(parseFloat(entry.current_fytd_net_outly_amt)) / 1000000000000)).toFixed(2),
+            "decoyDeficit": ((3.5 - Math.abs(parseFloat(entry.current_fytd_net_outly_amt))
+              / 1000000000000)).toFixed(2),
             "decoyDeficitColor": "hsl(0, 0%, 100%, 0.0)"
           })
         }
         apiData.push({
           "year": entry.record_fiscal_year,
-          "deficit": (Math.abs(parseFloat(entry.current_fytd_net_outly_amt)) / 1000000000000).toFixed(2),
+          "deficit": (Math.abs(parseFloat(entry.current_fytd_net_outly_amt))
+            / 1000000000000).toFixed(2),
           "deficitColor": deficitExplainerPrimary,
-          "decoyDeficit": ((3.5 - Math.abs(parseFloat(entry.current_fytd_net_outly_amt)) / 1000000000000)).toFixed(2),
+          "decoyDeficit": ((3.5 - Math.abs(parseFloat(entry.current_fytd_net_outly_amt))
+            / 1000000000000)).toFixed(2),
           "decoyDeficitColor": "hsl(0, 0%, 100%, 0.0)"
         })
         barCounter += 1;
       })
       setNumOfBars(barCounter);
-      setDate(getDateWithoutTimeZoneAdjust(new Date(result.data[result.data.length -1].record_date)));
+      setDate(getDateWithoutTimeZoneAdjust
+      (new Date(result.data[result.data.length -1].record_date)));
       const newData = preAPIData.concat(apiData);
       const latestYear = newData[newData.length - 1].year;
       const latestDeficit = newData[newData.length - 1].deficit;
@@ -106,14 +106,17 @@ export const DeficitTrendsBarChart = ({ width }) => {
     if (data.id !== 'decoyDeficit') {
       if (data.data.year === chartData[chartData.length - 1].year) {
         event.target.style.fill = barHighlightColor;
-        setLastBar(event.target.parentNode.parentNode.children[(barSVGs.length - 1) - numOfBars].firstChild);
+        setLastBar(event.target.parentNode.parentNode.children
+          [(barSVGs.length - 1) - numOfBars].firstChild);
         setHeaderYear(data.data.year);
         setHeaderDeficit(data.data.deficit);
       }
       else {
         event.target.style.fill = barHighlightColor;
-        event.target.parentNode.parentNode.children[(barSVGs.length - 1) - numOfBars].firstChild.style.fill = deficitExplainerPrimary;
-        setLastBar(event.target.parentNode.parentNode.children[(barSVGs.length - 1) - numOfBars].firstChild);
+        event.target.parentNode.parentNode.children
+          [(barSVGs.length - 1) - numOfBars].firstChild.style.fill = deficitExplainerPrimary;
+        setLastBar(event.target.parentNode.parentNode.children
+          [(barSVGs.length - 1) - numOfBars].firstChild);
         setHeaderYear(data.data.year);
         setHeaderDeficit(data.data.deficit);
       }
@@ -123,8 +126,10 @@ export const DeficitTrendsBarChart = ({ width }) => {
         const parentG = event.target.parentNode;
         const realBar = barSVGs.find((element) => element === parentG);
         const indexOfRealBar = barSVGs.indexOf(realBar) - numOfBars;
-        event.target.parentNode.parentNode.children[indexOfRealBar].firstChild.style.fill = barHighlightColor;
-        setLastBar(event.target.parentNode.parentNode.children[(barSVGs.length - 1) - numOfBars].firstChild);
+        event.target.parentNode.parentNode.children[indexOfRealBar]
+          .firstChild.style.fill = barHighlightColor;
+        setLastBar(event.target.parentNode.parentNode
+          .children[(barSVGs.length - 1) - numOfBars].firstChild);
         const matchedBar = chartData.find((element) => element.year === data.data.year);
         setHeaderYear(matchedBar.year);
         setHeaderDeficit(matchedBar.deficit);
@@ -133,8 +138,10 @@ export const DeficitTrendsBarChart = ({ width }) => {
         const parentG = event.target.parentNode;
         const realBar = barSVGs.find((element) => element === parentG);
         const indexOfRealBar = barSVGs.indexOf(realBar) - numOfBars;
-        event.target.parentNode.parentNode.children[indexOfRealBar].firstChild.style.fill = barHighlightColor;
-        event.target.parentNode.parentNode.children[(barSVGs.length - 1) - numOfBars].firstChild.style.fill = deficitExplainerPrimary;
+        event.target.parentNode.parentNode
+          .children[indexOfRealBar].firstChild.style.fill = barHighlightColor;
+        event.target.parentNode.parentNode.children[(barSVGs.length - 1) - numOfBars]
+          .firstChild.style.fill = deficitExplainerPrimary;
         const matchedBar = chartData.find((element) => element.year === data.data.year);
         setHeaderYear(matchedBar.year);
         setHeaderDeficit(matchedBar.deficit);
@@ -151,7 +158,8 @@ export const DeficitTrendsBarChart = ({ width }) => {
       const barSVGs = Array.from(event.target.parentNode.parentNode.children);
       const realBar = barSVGs.find((element) => element === parentG);
       const indexOfRealBar = barSVGs.indexOf(realBar) - numOfBars;
-      event.target.parentNode.parentNode.children[indexOfRealBar].firstChild.style.fill = deficitExplainerPrimary;
+      event.target.parentNode.parentNode.children[indexOfRealBar]
+        .firstChild.style.fill = deficitExplainerPrimary;
     }
   }
 
@@ -239,7 +247,6 @@ export const DeficitTrendsBarChart = ({ width }) => {
             header={header}
             footer={footer}
             date={date}
-
           >
             <div className={barChart} onMouseLeave={resetHeaderValues} data-testid={'chartParent'}>
               <Bar


### PR DESCRIPTION
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-6741
No change in coverage
Since removing global overrides adjusted some styling on revenue charts, tweaks were made to ensure those charts also kept close to the mocks. 