### PR TITLE
FDG-7097 Date range filter is showing more years than expected in the Preview section for Treasury Certified Interest Rates: Annual dataset.

### DIFF
--- a/src/components/dataset-data/dataset-data-helper/dataset-data-helper.js
+++ b/src/components/dataset-data/dataset-data-helper/dataset-data-helper.js
@@ -1,4 +1,4 @@
-import { isBefore, subYears, format } from 'date-fns';
+import { isBefore, subYears, format, addDays } from 'date-fns';
 
 export const convertDate = (date) => {
   // .replace() resolves weird -1 day issue https://stackoverflow.com/a/31732581/564406
@@ -33,7 +33,8 @@ export const getPresetDateRange = (years, latest, earliest) => {
     : '1790/01/01';
   const earliestAsDate = new Date(stringDate);
   earliestAsDate.setHours(0, 0, 0, 0);
-  const yearsPrior = subYears(rangeTo, years);
+  let yearsPrior = subYears(rangeTo, years);
+  yearsPrior = addDays(yearsPrior, 1);
   yearsPrior.setHours(0, 0, 0, 0);
 
   const rangeFrom = isBefore(earliestAsDate, yearsPrior) ? yearsPrior : earliestAsDate;

--- a/src/components/dataset-data/test-helper.js
+++ b/src/components/dataset-data/test-helper.js
@@ -1,8 +1,9 @@
 import { TestData } from '../dtg-table/test-data';
-import { subYears, format } from 'date-fns';
+import { subYears, format, addDays } from 'date-fns';
 
 export const latestDate = '2020-04-13';
-const testDate = subYears(new Date(2020, 3, 13), 5);
+let testDate = subYears(new Date(2020, 3, 13), 5);
+testDate = addDays(testDate, 1);
 export const fivePrior = format(testDate, 'yyyy-MM-dd');
 
 const mockYears = {


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-7097

No change in coverage