### PR TITLE
troubleshoot sparkles for release 2023-08

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9646,9 +9646,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001480",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001480.tgz",
-      "integrity": "sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ=="
+      "version": "1.0.30001246",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001246.tgz",
+      "integrity": "sha512-Tc+ff0Co/nFNbLOrziBXmMVtpt9S2c2Y+Z9Nk9Khj09J+0zR9ejvIW5qkZAErCbOrVODCx/MN+GpB5FNBs5GFA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -16825,6 +16825,11 @@
             "normalize-url": "^6.0.1",
             "responselike": "^2.0.0"
           }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001269",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001269.tgz",
+          "integrity": "sha512-UOy8okEVs48MyHYgV+RdW1Oiudl1H6KolybD6ZquD0VcrPSgj25omXO1S7rDydjpqaISCwA8Pyx+jUQKZwWO5w=="
         },
         "core-js": {
           "version": "3.18.3",

--- a/src/layouts/explainer/sections/national-deficit/understanding/surplus-illustration/surplus-illustration.module.scss
+++ b/src/layouts/explainer/sections/national-deficit/understanding/surplus-illustration/surplus-illustration.module.scss
@@ -110,7 +110,7 @@
 }
 
 @media screen and (min-width: $breakpoint-lg) {
-  img {
+  .folderContent img {
     padding-right: 4rem;
   }
 }


### PR DESCRIPTION
re-center image by narrowing img style application. revert latest changes to caniuse dependencies that had been made as advised by warning when unit-tests run.

live coverage: 90.27%