### PR TITLE
FDG-6807 508 Compliance - Remove 'img' label from chart container for Debt over 100 years chart

### DIFF
--- a/src/layouts/explainer/explainer-components/chart-container/chart-container.jsx
+++ b/src/layouts/explainer/explainer-components/chart-container/chart-container.jsx
@@ -27,7 +27,7 @@ const ChartContainer = ({
   return (
     <div
       className={`${chartContainer}`}
-      role={"img"}
+      role={"figure"}
       aria-label={altText}
       style={{ ...customSpacing }}
     >

--- a/src/layouts/explainer/explainer-helpers/explainer-charting-helper.js
+++ b/src/layouts/explainer/explainer-helpers/explainer-charting-helper.js
@@ -10,6 +10,7 @@ export const applyChartScaling = (parent, chartWidth, chartHeight) => {
     svgChart.setAttribute('viewBox', `0 0 ${chartWidth} ${chartHeight}`);
     svgChart.setAttribute('height', '100%');
     svgChart.setAttribute('width', '100%');
+    svgChart.setAttribute('aria-label', 'Inner chart area');
   }
 };
 

--- a/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-over-last-100y-linechart/debt-over-last-100y-linechart.jsx
+++ b/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-over-last-100y-linechart/debt-over-last-100y-linechart.jsx
@@ -214,12 +214,13 @@ const DebtOverLast100y = ({ cpiDataByYear, width }) => {
               customHeaderStyles={customHeaderStyles}
               customFooterSpacing={customFooterSpacing}
             >
+              // TODO: Move these mouse handlers to a different element, maybe chart container?
+              {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
               <div
                 className={lineChart}
                 data-testid={'totalDebtChartParent'}
                 onMouseEnter={handleChartMouseEnter}
                 onMouseLeave={handleChartMouseLeave}
-                role={'presentation'}
               >
                 <Line
                   data={chartData}

--- a/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-trends-over-time/debt-trends-over-time-chart.module.scss.d.ts
+++ b/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-trends-over-time/debt-trends-over-time-chart.module.scss.d.ts
@@ -65,6 +65,8 @@ export const debtExplainerSecondary: string;
 export const debtExplainerLightSecondary: string;
 export const container: string;
 export const lineChartContainer: string;
+export const inAnimation: string;
+export const animationCrosshair: string;
 export const title: string;
 export const simple: string;
 export const titleBreakdown: string;


### PR DESCRIPTION
No change in coverage
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-6807