### PR TITLE
FDG-5403 Debt 100y chart animation - fix chart header updates

### DIFF
--- a/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.jsx
+++ b/src/layouts/explainer/sections/federal-spending/spending-trends/total-spending-chart/total-spending-chart-helper.jsx
@@ -291,10 +291,12 @@ export const LineChartCustomSlices = (
       slices.forEach((slice, index) => {
         setTimeout(() => {
           setCurrentSlice(slice);
+          mouseMove(slice);
         }, (50 * index) + 550);
       });
       setTimeout(() => {
         setCurrentSlice(slices[slices.length - 1]);
+        mouseMove(slices[slices.length - 1]);
       }, (50 * (slices.length + 1)) + 550);
     }
   }, [inView, animationTriggeredOnce, slices]);

--- a/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-over-last-100y-linechart/debt-over-last-100y-linechart-helper.js
+++ b/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-over-last-100y-linechart/debt-over-last-100y-linechart-helper.js
@@ -71,11 +71,11 @@ export const dataHeader = headingValues => {
   return (
     <div className={styles.headerContainer}>
       <div>
-        <div className={styles.header}>{fiscalYear}</div>
+        <div className={styles.header} data-testid="dynamic-year-header">{fiscalYear}</div>
         <span className={styles.subHeader}>Fiscal Year</span>
       </div>
       <div>
-        <div className={styles.header}>{totalDebt}</div>
+        <div className={styles.header} data-testid="dynamic-value-header">{totalDebt}</div>
         <span className={styles.subHeader}>Total Debt</span>
       </div>
     </div>

--- a/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-over-last-100y-linechart/debt-over-last-100y-linechart.jsx
+++ b/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-over-last-100y-linechart/debt-over-last-100y-linechart.jsx
@@ -234,11 +234,11 @@ const DebtOverLast100y = ({ cpiDataByYear, width }) => {
                     lineChartCustomPoints,
                     props =>
                       LineChartCustomSlices({
-                          ...props,
-                          groupMouseLeave: handleGroupOnMouseLeave,
-                          mouseMove: handleMouseLeave,
-                          inView
-                        }
+                        ...props,
+                        groupMouseLeave: handleGroupOnMouseLeave,
+                        mouseMove: handleMouseLeave,
+                        inView,
+                      }
                       ),
                     'mesh',
                     'legends',

--- a/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-over-last-100y-linechart/debt-over-last-100y-linechart.spec.js
+++ b/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-over-last-100y-linechart/debt-over-last-100y-linechart.spec.js
@@ -93,7 +93,7 @@ describe('National Debt Over the Last 100 Years Chart', () => {
     ).toBeInTheDocument();
   });
 
-  it.skip('animates the chart when it is scrolled into view', async () => {
+  it('animates the chart updating header values when it is scrolled into view', async () => {
 
     jest.useFakeTimers();
 
@@ -110,6 +110,8 @@ describe('National Debt Over the Last 100 Years Chart', () => {
 
     // find an element corresponding to the selected point
     let points = await getByTestId('customPoints');
+    let yearHeader = await getByTestId('dynamic-year-header');
+    let debtAmountHeader = await getByTestId('dynamic-value-header');
     const circleElem = await points.querySelector('circle:first-child');
     let updatedCircleElem;
     let updatedPointPosition;
@@ -122,6 +124,11 @@ describe('National Debt Over the Last 100 Years Chart', () => {
       updatedCircleElem = points.querySelector('circle:first-child');
       updatedPointPosition = {x: updatedCircleElem.getAttribute('cx'), y: updatedCircleElem.getAttribute('cy')};
       expect(initialPointPosition).toStrictEqual(updatedPointPosition);
+      yearHeader = await getByTestId('dynamic-year-header');
+      debtAmountHeader = await getByTestId('dynamic-value-header');
+      expect(yearHeader.textContent).toContain('2022');
+      expect(debtAmountHeader.textContent).toContain('$30.93 T');
+      //expect(debtAmountHeader).toStrictEqual('rong');
     });
 
     // explicitly declare that the chart IS NOW scrolled into view and confirm animation is underway
@@ -131,6 +138,10 @@ describe('National Debt Over the Last 100 Years Chart', () => {
       updatedCircleElem = points.querySelector('circle:first-child');
       updatedPointPosition = {x: updatedCircleElem.getAttribute('cx'), y: updatedCircleElem.getAttribute('cy')};
       expect(initialPointPosition.x - updatedPointPosition.x).toBeGreaterThan(0);
+      yearHeader = await getByTestId('dynamic-year-header');
+      debtAmountHeader = await getByTestId('dynamic-value-header');
+      expect(yearHeader.textContent).toContain('1931');
+      expect(debtAmountHeader.textContent).toContain('$19.6');
     });
 
     // confirm that point eventually returns to home position
@@ -140,6 +151,10 @@ describe('National Debt Over the Last 100 Years Chart', () => {
       updatedCircleElem = points.querySelector('circle:first-child');
       updatedPointPosition = {x: updatedCircleElem.getAttribute('cx'), y: updatedCircleElem.getAttribute('cy')};
       expect(initialPointPosition).toStrictEqual(updatedPointPosition);
+      yearHeader = await getByTestId('dynamic-year-header');
+      debtAmountHeader = await getByTestId('dynamic-value-header');
+      expect(yearHeader.textContent).toContain('2022');
+      expect(debtAmountHeader.textContent).toContain('$30.93 T');
     });
   });
 });


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-5403 Re-enable accidentally skipped unit test, add logic to ensure chart headers are updated on animation effect.

Line Cov: 90.29%