### PR TITLE
FDG-7005 Create a new GA4 property in the USAs non-DAP GA Account

### DIFF
--- a/src/components/page-helmet/page-helmet.jsx
+++ b/src/components/page-helmet/page-helmet.jsx
@@ -61,7 +61,7 @@ const PageHelmet = ({ pageTitle, description, descriptionGenerator, keywords, im
   return (
     <Helmet>
       {/*Google Analytics 4 Tag  */}
-      <script async src="https://www.googletagmanager.com/gtag/js?id=G-ME8TBPZYXP"/>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-ME8TBPZYXP" />
       <script>
         {`window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}

--- a/src/components/page-helmet/page-helmet.jsx
+++ b/src/components/page-helmet/page-helmet.jsx
@@ -60,6 +60,16 @@ const PageHelmet = ({ pageTitle, description, descriptionGenerator, keywords, im
 
   return (
     <Helmet>
+      {/*Google Analytics 4 Tag  */}
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-ME8TBPZYXP"/>
+      <script>
+        {`window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-ME8TBPZYXP');`}
+      </script>
+      {/*Google Analytics 4 Tag  */}
       {/* Version info is placed inside a script comment below because both react jsx
           and gatsby are unfriendly toward rendering <!-- html comments --> into built pages.
       */}


### PR DESCRIPTION
No change in coverage
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-7005

This PR is to merge in the code added the GA4 tag that is attached to the new property to the page-helmet. Data collection has been verified in the analytics dashboard. 