### PR TITLE
FDG-6999 Update Glossary Definition Popover and Term Buttons within the Explainer Pages

### DIFF
--- a/src/components/glossary/glossary-header/glossary-header.tsx
+++ b/src/components/glossary/glossary-header/glossary-header.tsx
@@ -21,11 +21,12 @@ import { searchBarTheme, useStyles } from './theme';
 interface IGlossaryHeader {
   filter: string,
   clickHandler: (e) => void,
-  filterHandler: (e) => void
+  filterHandler: (e) => void,
+  glossaryRef: any,
 }
 
 
-const GlossaryHeader:FunctionComponent<IGlossaryHeader> = ({filter, clickHandler, filterHandler}) => {
+const GlossaryHeader:FunctionComponent<IGlossaryHeader> = ({filter, clickHandler, filterHandler, glossaryRef}) => {
   const onSearchBarChange = (event) => {
     const val = (event && event.target) ? event.target.value : '';
     filterHandler(val);
@@ -39,7 +40,7 @@ const GlossaryHeader:FunctionComponent<IGlossaryHeader> = ({filter, clickHandler
           <FontAwesomeIcon icon={faBook as IconProp} className={bookIcon} />
           GLOSSARY
         </div>
-        <button onClick={clickHandler} className={closeButton} aria-label={'Close glossary'}>
+        <button onClick={clickHandler} onKeyPress={clickHandler} className={closeButton} aria-label={'Close glossary'} ref={glossaryRef}>
           <FontAwesomeIcon icon={faXmark as IconProp} className={closeIcon} />
         </button>
       </div>

--- a/src/components/glossary/glossary-term/glossary-popover-definition.jsx
+++ b/src/components/glossary/glossary-term/glossary-popover-definition.jsx
@@ -152,7 +152,13 @@ const GlossaryPopoverDefinition = ({ term, page, glossary, glossaryClickHandler,
         >
           <div className={glossaryText}>
             <div className={header}>
-              <FontAwesomeIcon className={mobileFA} icon={faXmark} onClick={handleClose} />
+              <FontAwesomeIcon
+                className={mobileFA}
+                icon={faXmark}
+                onClick={handleClose}
+                onKeyPress={handleClose}
+                tabIndex={0}
+              />
               <span>Definition</span>
             </div>
             <div className={termNameText}>{termName}</div>

--- a/src/components/glossary/glossary-term/glossary-popover-definition.spec.js
+++ b/src/components/glossary/glossary-term/glossary-popover-definition.spec.js
@@ -130,5 +130,26 @@ describe('glossary term',() => {
     expect(window.history.pushState).toHaveBeenCalled();
   })
 
+  it('closes the popover when the full glossary tab is opened', () => {
+    const termText = 'Hello';
+    const testPage = 'Another Test Page';
+
+    window.history.pushState = jest.fn();
+    const clickHandler = jest.fn();
+
+    const { getByRole, queryByRole } = render(
+      <GlossaryPopoverDefinition term={termText} page={testPage} glossary={testGlossary} glossaryClickHandler={clickHandler}>
+        {termText}
+      </GlossaryPopoverDefinition>
+    );
+
+    const glossaryTermButton = getByRole('button', { name: termText });
+    glossaryTermButton.click();
+
+    const viewInGlossaryButton = getByRole('button', { name: 'View in glossary' })
+    viewInGlossaryButton.click();
+
+    expect(queryByRole('button', { name: 'View in glossary' })).not.toBeInTheDocument();
+  })
 
 });

--- a/src/components/glossary/glossary.tsx
+++ b/src/components/glossary/glossary.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-import React, { FunctionComponent, useEffect, useState } from 'react';
+import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { glossaryContainer, glossaryHeaderContainer, open, overlay, tray } from './glossary.module.scss';
 import GlossaryHeader from './glossary-header/glossary-header';
 import GlossaryListContainer from './glossary-list/glossary-list-container';
@@ -35,6 +35,7 @@ const Glossary:FunctionComponent<IGlossary> = ({ termList, activeState, setActiv
   const sortedTermList = getSortedGlossaryList(termList);
   const [queryTerm, setQueryTerm] = useState(getQueryTerm(termList));
   const [initialQuery, setInitialQuery] = useState(false);
+  const glossaryRef = useRef(null);
 
   useEffect(() => {
     if (!initialQuery) {
@@ -58,6 +59,14 @@ const Glossary:FunctionComponent<IGlossary> = ({ termList, activeState, setActiv
     }
   }, [glossaryEvent]);
 
+  useEffect(() => {
+    if (activeState) {
+      const node = glossaryRef.current;
+      if (node) {
+        node.focus();
+      }
+    }
+  }, [activeState])
   const toggleState = (e) => {
     if (!e.key || e.key === 'Enter') {
       setActiveState(!activeState);
@@ -79,7 +88,7 @@ const Glossary:FunctionComponent<IGlossary> = ({ termList, activeState, setActiv
         {activeState && (
           <>
             <div className={glossaryHeaderContainer}>
-              <GlossaryHeader clickHandler={toggleState} filter={filter} filterHandler={setFilter} />
+              <GlossaryHeader clickHandler={toggleState} filter={filter} filterHandler={setFilter} glossaryRef={glossaryRef} />
             </div>
             <GlossaryListContainer
               sortedTermList={sortedTermList}


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-6999

Keyboard accessibility has been enhanced so you can now tab into the glossary panel and close out of the panel. The focus will still reset to the top of the page after the panel has closed, a follow up ticket has been created to save the tab location within the page prior to opening the panel. 