### PR TITLE
FDG-7376 Spending explainer glossary panel is not sliding open when clicking button

### DIFF
--- a/src/layouts/explainer/sections/federal-spending/federal-spending.jsx
+++ b/src/layouts/explainer/sections/federal-spending/federal-spending.jsx
@@ -32,7 +32,7 @@ const federalSpendingSection = [
     id: federalSpendingSectionIds[1],
     title: "Federal Spending Overview",
     component: (glossary, glossaryClickHandler, cpiDataByYear) => (
-      <SpendingOverview glossary={glossary} glossaryEventHandler={glossaryClickHandler} />
+      <SpendingOverview glossary={glossary} glossaryClickHandler={glossaryClickHandler} />
     ),
   },
   {


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-7376

No change in coverage 