### PR TITLE
FDG-7478 "Spending - Related Datasets" are not displaying "Citation Click - Spending"

### DIFF
--- a/src/components/dataset-card/dataset-card.tsx
+++ b/src/components/dataset-card/dataset-card.tsx
@@ -31,7 +31,7 @@ const DatasetCard: FunctionComponent<DatasetCardProps> = ({
   dataset,
   context,
   referrer,
-  explainer
+  explainer,
 }) => {
   const cardLink = `/datasets${dataset.slug}`;
   const [applyFocusStyle, setApplyFocusStyle] = useState(false);
@@ -45,7 +45,12 @@ const DatasetCard: FunctionComponent<DatasetCardProps> = ({
           category: `Explainers`,
           action: 'Citation Click',
           label: `${referrer} - ${context}`
-        })
+        });
+        (window as any).dataLayer = (window as any).dataLayer || [];
+        (window as any).dataLayer.push({
+          'event': `${referrer} - Citation Click`,
+          'eventLabel': `${dataset.name}`,
+        });
       }
       else {
         Analytics.event({
@@ -61,13 +66,12 @@ const DatasetCard: FunctionComponent<DatasetCardProps> = ({
         });
       }
     }
-
     navigate(cardLink);
   };
 
   return (
     <MuiThemeProvider theme={theme}>
-      <Card className={applyFocusStyle ? focusStyle : card} onClick={clickHandler} >
+      <Card className={applyFocusStyle ? focusStyle : card} onClick={clickHandler} id={explainer ? dataset.name : null}>
         <CardActionArea
           onFocus={() => setApplyFocusStyle(true)}
           onBlur={() => setApplyFocusStyle(false)}

--- a/src/components/dataset-card/dataset-card.tsx
+++ b/src/components/dataset-card/dataset-card.tsx
@@ -46,10 +46,16 @@ const DatasetCard: FunctionComponent<DatasetCardProps> = ({
           action: 'Citation Click',
           label: `${referrer} - ${context}`
         });
+        // GA4 Data Layer - Dataset Click
         (window as any).dataLayer = (window as any).dataLayer || [];
         (window as any).dataLayer.push({
           'event': `${referrer} - Citation Click`,
           'eventLabel': `${dataset.name}`,
+        });
+        // GA4 Data Layer - Clear
+        (window as any).dataLayer.push({
+          'event': `${referrer} - Citation Click`,
+          'eventLabel': undefined,
         });
       }
       else {


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-7478

No change in coverage 

Citation clicks should now fire for the related dataset cards on all explainer pages