### PR TITLE
FDG-7525 Design Review 

### DIFF
--- a/src/components/data-table/data-table-header/data-table-header.module.scss
+++ b/src/components/data-table/data-table-header/data-table-header.module.scss
@@ -7,6 +7,8 @@
   min-width: 1.75rem;
   border-radius: 1.25rem;
   display: flex;
+  align-items: center;
+  justify-content: center;
   margin-left: 0.375rem;
   cursor: pointer;
 }
@@ -20,11 +22,11 @@
 }
 
 .sortArrow, .defaultSortArrow {
-  margin: auto 0.375rem;
   width: 1rem !important;
 }
 
 .sortArrow {
+  margin: auto 0.375rem;
   color: white;
 }
 


### PR DESCRIPTION
Because the default sort arrow is rotated 90 deg, the original icon padding was applying before the rotation 
https://federal-spending-transparency.atlassian.net/browse/FDG-7525