### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Clone this project using this command:
 `git clone https://github.com/fedspendingtransparency/fiscal-data.git`
 
 Install dependencies:
-`npm install`
+`npm install --legacy-peer-deps`
 
 Start the project on a local server:
 `npm start`


### PR DESCRIPTION
`npm install` requires the `--legacy-peer-deps` until peer dependencies for Nivo and/or React are updated.