### PR TITLE
FDG-8279 SLGS dataset it is displaying 'undefined%" for Annualized Effective Rate and "NaN" for Daily Factor when in Toggle Experimental feature is on.

### DIFF
--- a/src/components/data-table/data-table-helper.tsx
+++ b/src/components/data-table/data-table-helper.tsx
@@ -54,6 +54,10 @@ export const columnsConstructorData = (rawData: any, hideColumns: string[], tabl
                   formattedValue = numberFormatter.format(value);
                 }
 
+                if (tableName === 'Demand Deposit Rate' && field === 'daily_factor') {
+                  formattedValue = Number(value).toFixed(8);
+                }
+
                 return formattedValue;
               },
             } as ColumnDef<string, number>;

--- a/src/components/data-table/data-table-helper.tsx
+++ b/src/components/data-table/data-table-helper.tsx
@@ -62,7 +62,11 @@ export const columnsConstructorData = (rawData: any, hideColumns: string[], tabl
               accessorKey: field,
               header: label,
               cell: ({ getValue }) => {
-                return `${getValue()}%`;
+                if (getValue() !== undefined) {
+                  return `${getValue()}%`;
+                } else {
+                  return '';
+                }
               },
             } as ColumnDef<string, string>;
           } else if (rawData.meta.dataTypes[field] === 'SMALL_FRACTION') {

--- a/src/components/dtg-table/dtg-table.jsx
+++ b/src/components/dtg-table/dtg-table.jsx
@@ -355,7 +355,7 @@ export default function DtgTable({
   useEffect(() => {
     if (tableProps) {
       if (dePaginated !== undefined) {
-        if (dePaginated !== null && selectedTable.rowCount <= REACT_TABLE_MAX_NON_PAGINATED_SIZE) {
+        if (dePaginated !== null && tableMeta['total-count'] <= REACT_TABLE_MAX_NON_PAGINATED_SIZE) {
           setReactTableData(dePaginated);
           setManualPagination(false);
         } else {


### PR DESCRIPTION
Ticket: SLGS dataset it is displaying 'undefined%" for Annualized Effective Rate and "NaN" for Daily Factor when in Toggle Experimental feature is on.

-- Issue was caused y table loading incorrect data from previous table after failing data load check due to the table being treated as large when it was a smaller section of the larger table. Data now loads correctly for this scenario. 