### PR TITLE
FDG-8413 Dataset Detail Page TRRE Select Columns Overlay Should Be Wider on Mobile

### DIFF
--- a/src/components/data-table/data-table.module.scss
+++ b/src/components/data-table/data-table.module.scss
@@ -100,6 +100,5 @@ $borderRadius: 5px;
   .selectColumnPanelInactive {
     height: 565px;
     order: 2;
-    width: 39.6%;
   }
 }

--- a/src/components/data-table/data-table.module.scss
+++ b/src/components/data-table/data-table.module.scss
@@ -100,5 +100,6 @@ $borderRadius: 5px;
   .selectColumnPanelInactive {
     height: 565px;
     order: 2;
+    width: 450px;
   }
 }


### PR DESCRIPTION
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-8413

NOTE: The column select did not used to have an enforced width. Now a width is enforced that tracks to within a % of the generated width on mobile from the previous iteration. 
