### PR TITLE
Fdg 8292 site error messages

### DIFF
--- a/src/components/pageError/page-error-text.jsx
+++ b/src/components/pageError/page-error-text.jsx
@@ -85,9 +85,8 @@ const PageErrorText = ({ fallback }) => (
     <Header>Oops... there's been a glitch in the data.</Header>
     {fallback ? <FallbackText /> : <NotFoundText />}
     <PTag>
-      Want to get in touch or send in general comments about the site? Send a message{' '}
-      <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov?subject=Contact Us">via email</CustomLink>, and our team will respond at our earliest
-      opportunity.
+      Want to get in touch or send in general comments about the site? Contact us via email at{' '}
+      <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov?subject=Contact Us">fiscaldata@fiscal.treasury.gov</CustomLink> for further assistance. Thank you!
     </PTag>
     <NotFoundGraphicHolder />
   </Wrapper>

--- a/src/components/site-header/banner-types/content-unavailable.jsx
+++ b/src/components/site-header/banner-types/content-unavailable.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import AnnouncementBanner from '../../announcement-banner/announcement-banner';
+import CustomLink from '../../links/custom-link/custom-link';
+import { bannerHeading, bannerContent} from './../site-header.module.scss';
+
+const ContentUnavailable = () => {
+
+return (
+      <AnnouncementBanner closable={false}>
+        <div className={bannerHeading}> Content Temporarily Unavailable:</div>
+        <div className={bannerContent}>
+          The Fiscal Data team is working to address the current issue with this page. Please check back later or contact us via email at{' '}
+          <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov">fiscaldata@fiscal.treasury.gov</CustomLink> for further assistance. Thank you.
+        </div>
+      </AnnouncementBanner>
+  );
+};
+export default ContentUnavailable;

--- a/src/components/site-header/banner-types/content-unavailable.jsx
+++ b/src/components/site-header/banner-types/content-unavailable.jsx
@@ -5,13 +5,13 @@ import { bannerHeading, bannerContent} from './../site-header.module.scss';
 const ContentUnavailable = () => {
 
 return (
-      <div>
+      <>
         <div className={bannerHeading}> Content Temporarily Unavailable:</div>
         <div className={bannerContent}>
           The Fiscal Data team is working to address the current issue with this page. Please check back later or contact us via email at{' '}
           <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov">fiscaldata@fiscal.treasury.gov</CustomLink> for further assistance. Thank you.
         </div>
-      </div>
+      </>
   );
 };
 export default ContentUnavailable;

--- a/src/components/site-header/banner-types/content-unavailable.jsx
+++ b/src/components/site-header/banner-types/content-unavailable.jsx
@@ -1,18 +1,17 @@
 import React from 'react';
-import AnnouncementBanner from '../../announcement-banner/announcement-banner';
 import CustomLink from '../../links/custom-link/custom-link';
 import { bannerHeading, bannerContent} from './../site-header.module.scss';
 
 const ContentUnavailable = () => {
 
 return (
-      <AnnouncementBanner closable={false}>
+      <div>
         <div className={bannerHeading}> Content Temporarily Unavailable:</div>
         <div className={bannerContent}>
           The Fiscal Data team is working to address the current issue with this page. Please check back later or contact us via email at{' '}
           <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov">fiscaldata@fiscal.treasury.gov</CustomLink> for further assistance. Thank you.
         </div>
-      </AnnouncementBanner>
+      </div>
   );
 };
 export default ContentUnavailable;

--- a/src/components/site-header/banner-types/content-unavailable.spec.js
+++ b/src/components/site-header/banner-types/content-unavailable.spec.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react'; 
+import ContentUnavailable from './content-unavailable';
+
+describe('ContentUnavailable', () => {
+
+  it('renders the content unavailable message', () => {
+    render(<ContentUnavailable />);
+    const regex = new RegExp('The Fiscal Data team is working to address the current issue with this page.', 'i')
+    expect(screen.getByText(`Content Temporarily Unavailable:`)).toBeInTheDocument();
+    expect(screen.getByText(regex)).toBeInTheDocument();
+  });
+
+  it('contains an email link with the correct address', () => {
+    render(<ContentUnavailable />);
+
+    const mailtoLink = screen.getByRole('link');
+    expect(mailtoLink).toHaveAttribute('href', 'mailto:fiscaldata@fiscal.treasury.gov');
+  });
+
+  it('does not close when closable is set to false', () => {
+    render(<ContentUnavailable />);
+    expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+  });
+
+});

--- a/src/components/site-header/banner-types/dataset-unavailable.jsx
+++ b/src/components/site-header/banner-types/dataset-unavailable.jsx
@@ -6,14 +6,14 @@ const DatasetUnavailable = ({ datasetPageName }) => {
 
 
 return (
-      <div>
+      <>
         <div className={bannerHeading}> Dataset Unavailable:</div>
         <div className={bannerContent}>
           Fiscal Data is currently experiencing an issue with the {datasetPageName}. 
           Our Fiscal Service team is working to address the issue. Please check back later or contact us via email at {' '}
           <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov">fiscaldata@fiscal.treasury.gov</CustomLink> for further assistance. Thank you.
         </div>
-      </div>
+      </>
   );
 };
 export default DatasetUnavailable;

--- a/src/components/site-header/banner-types/dataset-unavailable.jsx
+++ b/src/components/site-header/banner-types/dataset-unavailable.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import AnnouncementBanner from '../../announcement-banner/announcement-banner';
+import CustomLink from '../../links/custom-link/custom-link';
+import { bannerHeading, bannerContent} from './../site-header.module.scss';
+
+const DatasetUnavailable = (datasetPageName) => {
+
+return (
+      <AnnouncementBanner closable={false}>
+        <div className={bannerHeading}> Dataset Unavailable:</div>
+        <div className={bannerContent}>
+          Fiscal Data is currently experiencing an issue with the {datasetPageName}. 
+          Our Fiscal Service team is working to address the issue. Please check back later or contact us via email at
+          <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov">fiscaldata@fiscal.treasury.gov</CustomLink> for further assistance. Thank you.
+        </div>
+      </AnnouncementBanner>
+  );
+};
+export default DatasetUnavailable;

--- a/src/components/site-header/banner-types/dataset-unavailable.jsx
+++ b/src/components/site-header/banner-types/dataset-unavailable.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AnnouncementBanner from '../../announcement-banner/announcement-banner';
 import CustomLink from '../../links/custom-link/custom-link';
 import { bannerHeading, bannerContent} from './../site-header.module.scss';
 
@@ -7,14 +6,14 @@ const DatasetUnavailable = ({ datasetPageName }) => {
 
 
 return (
-      <AnnouncementBanner closable={false}>
+      <div>
         <div className={bannerHeading}> Dataset Unavailable:</div>
         <div className={bannerContent}>
           Fiscal Data is currently experiencing an issue with the {datasetPageName}. 
           Our Fiscal Service team is working to address the issue. Please check back later or contact us via email at {' '}
           <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov">fiscaldata@fiscal.treasury.gov</CustomLink> for further assistance. Thank you.
         </div>
-      </AnnouncementBanner>
+      </div>
   );
 };
 export default DatasetUnavailable;

--- a/src/components/site-header/banner-types/dataset-unavailable.jsx
+++ b/src/components/site-header/banner-types/dataset-unavailable.jsx
@@ -3,14 +3,15 @@ import AnnouncementBanner from '../../announcement-banner/announcement-banner';
 import CustomLink from '../../links/custom-link/custom-link';
 import { bannerHeading, bannerContent} from './../site-header.module.scss';
 
-const DatasetUnavailable = (datasetPageName) => {
+const DatasetUnavailable = ({ datasetPageName }) => {
+
 
 return (
       <AnnouncementBanner closable={false}>
         <div className={bannerHeading}> Dataset Unavailable:</div>
         <div className={bannerContent}>
           Fiscal Data is currently experiencing an issue with the {datasetPageName}. 
-          Our Fiscal Service team is working to address the issue. Please check back later or contact us via email at
+          Our Fiscal Service team is working to address the issue. Please check back later or contact us via email at {' '}
           <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov">fiscaldata@fiscal.treasury.gov</CustomLink> for further assistance. Thank you.
         </div>
       </AnnouncementBanner>

--- a/src/components/site-header/banner-types/datatset-unavailable.spec.js
+++ b/src/components/site-header/banner-types/datatset-unavailable.spec.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react'; 
+import DatasetUnavailable from './dataset-unavailable'; 
+
+describe('DatasetUnavailable', () => {
+  const testDatasetName = 'Test Dataset';
+  
+  it('renders with the correct dataset name', () => {
+    render(<DatasetUnavailable datasetPageName={testDatasetName} />);
+    const regex = new RegExp('Test Dataset', 'i')
+
+    expect(screen.getByText(`Dataset Unavailable:`)).toBeInTheDocument();
+    expect(screen.getByText(regex)).toBeInTheDocument();
+  });
+
+  it('contains an email link with the correct address', () => {
+    render(<DatasetUnavailable datasetPageName={testDatasetName} />);
+
+    const mailtoLink = screen.getByRole('link');
+    expect(mailtoLink).toHaveAttribute('href', 'mailto:fiscaldata@fiscal.treasury.gov');
+  });
+
+  it('does not close when closable is set to false', () => {
+    render(<DatasetUnavailable datasetPageName={testDatasetName} />);
+    expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+  });
+
+});

--- a/src/components/site-header/site-header.jsx
+++ b/src/components/site-header/site-header.jsx
@@ -10,6 +10,7 @@ import Analytics from '../../utils/analytics/analytics';
 import LocationAware from '../location-aware/location-aware';
 import Glossary from '../glossary/glossary';
 import DesktopMenu from './desktop-menu/desktop-menu';
+import ContentUnavailable from './banner-types/content-unavailable';
 import AnnouncementBanner from '../announcement-banner/announcement-banner';
 import { NOTIFICATION_BANNER_DISPLAY_PAGES, NOTIFICATION_BANNER_DISPLAY_PATHS } from 'gatsby-env-variables';
 import CustomLink from '../links/custom-link/custom-link';
@@ -71,13 +72,7 @@ const SiteHeader = ({ lowerEnvMsg, location }) => {
   return (
     <>
       {displayBanner() && (
-        <AnnouncementBanner closable={false}>
-          <div className={bannerHeading}> Content Temporarily Unavailable:</div>
-          <div className={bannerContent}>
-            The Fiscal Data team is working diligently to address the current issue with this page. Please check back later or contact us{' '}
-            <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov">via email</CustomLink> for further assistance. Thank you.
-          </div>
-        </AnnouncementBanner>
+        {ContentUnavailable}
       )}
       <header>
         <OfficialBanner data-testid="officialBanner" />

--- a/src/components/site-header/site-header.jsx
+++ b/src/components/site-header/site-header.jsx
@@ -72,7 +72,9 @@ const SiteHeader = ({ lowerEnvMsg, location }) => {
   return (
     <>
       {displayBanner() && (
-        {ContentUnavailable}
+        <AnnouncementBanner closable={false}>
+          <ContentUnavailable />
+        </AnnouncementBanner>
       )}
       <header>
         <OfficialBanner data-testid="officialBanner" />

--- a/src/layouts/experimental/experimental.jsx
+++ b/src/layouts/experimental/experimental.jsx
@@ -81,7 +81,8 @@ const ExperimentalPage = () => {
 
   return (
     <ErrorBoundary FallbackComponent={fallbackComponent}>
-            <DatasetUnavailable />
+            <DatasetUnavailable datasetPageName={'Trash Can'} />
+            <ContentUnavailable />
       <SiteLayout>
         <h2>FootNote Paragraph</h2>
         <p>

--- a/src/layouts/experimental/experimental.jsx
+++ b/src/layouts/experimental/experimental.jsx
@@ -12,8 +12,9 @@ import AFGDeficitPOC from './charts/afgOverviewDeficitChartPOC';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Legend } from 'recharts';
 import { totalDebtData } from './experimental-helper';
-import ContentUnavailable from '../../components/site-header/banner-types/content-unavailable';
-import DatasetUnavailable from '../../components/site-header/banner-types/dataset-unavailable';
+import AnnouncementBanner from '../../components/announcement-banner/announcement-banner';
+import * as styles from '../../components/site-header/site-header.module.scss';
+
 const fallbackComponent = () => {
   return <div className={fallback}>Something went wrong. Please refresh the page to try again.</div>;
 };
@@ -81,8 +82,13 @@ const ExperimentalPage = () => {
 
   return (
     <ErrorBoundary FallbackComponent={fallbackComponent}>
-            <DatasetUnavailable datasetPageName={'Trash Can'} />
-            <ContentUnavailable />
+      <AnnouncementBanner>
+        <div className={styles.bannerHeading}> Content Temporarily Unavailable: </div>
+        <div className={styles.bannerContent}>
+          The Fiscal Data team is working diligently to address the current issue with this page. Please check back later or contact us{' '}
+          <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov">via email</CustomLink> for further assistance. Thank you.
+        </div>
+      </AnnouncementBanner>
       <SiteLayout>
         <h2>FootNote Paragraph</h2>
         <p>

--- a/src/layouts/experimental/experimental.jsx
+++ b/src/layouts/experimental/experimental.jsx
@@ -12,9 +12,8 @@ import AFGDeficitPOC from './charts/afgOverviewDeficitChartPOC';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Legend } from 'recharts';
 import { totalDebtData } from './experimental-helper';
-import AnnouncementBanner from '../../components/announcement-banner/announcement-banner';
-import * as styles from '../../components/site-header/site-header.module.scss';
-
+import ContentUnavailable from '../../components/site-header/banner-types/content-unavailable';
+import DatasetUnavailable from '../../components/site-header/banner-types/dataset-unavailable';
 const fallbackComponent = () => {
   return <div className={fallback}>Something went wrong. Please refresh the page to try again.</div>;
 };
@@ -82,13 +81,7 @@ const ExperimentalPage = () => {
 
   return (
     <ErrorBoundary FallbackComponent={fallbackComponent}>
-      <AnnouncementBanner>
-        <div className={styles.bannerHeading}> Content Temporarily Unavailable: </div>
-        <div className={styles.bannerContent}>
-          The Fiscal Data team is working diligently to address the current issue with this page. Please check back later or contact us{' '}
-          <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov">via email</CustomLink> for further assistance. Thank you.
-        </div>
-      </AnnouncementBanner>
+            <DatasetUnavailable />
       <SiteLayout>
         <h2>FootNote Paragraph</h2>
         <p>

--- a/src/layouts/experimental/experimental.jsx
+++ b/src/layouts/experimental/experimental.jsx
@@ -12,8 +12,8 @@ import AFGDeficitPOC from './charts/afgOverviewDeficitChartPOC';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Legend } from 'recharts';
 import { totalDebtData } from './experimental-helper';
+import ContentUnavailable from '../../components/site-header/banner-types/content-unavailable';
 import AnnouncementBanner from '../../components/announcement-banner/announcement-banner';
-import * as styles from '../../components/site-header/site-header.module.scss';
 
 const fallbackComponent = () => {
   return <div className={fallback}>Something went wrong. Please refresh the page to try again.</div>;
@@ -82,12 +82,9 @@ const ExperimentalPage = () => {
 
   return (
     <ErrorBoundary FallbackComponent={fallbackComponent}>
+
       <AnnouncementBanner>
-        <div className={styles.bannerHeading}> Content Temporarily Unavailable: </div>
-        <div className={styles.bannerContent}>
-          The Fiscal Data team is working diligently to address the current issue with this page. Please check back later or contact us{' '}
-          <CustomLink url="mailto:fiscaldata@fiscal.treasury.gov">via email</CustomLink> for further assistance. Thank you.
-        </div>
+        <ContentUnavailable />
       </AnnouncementBanner>
       <SiteLayout>
         <h2>FootNote Paragraph</h2>


### PR DESCRIPTION
[FDG-8292](https://federal-spending-transparency.atlassian.net/browse/FDG-8292)

Test: 90.00 yikes. 

I choose not to wrap the banner component with Announcement Banner for two reason. 

  - First Announcement Banner is already being called and in one place. Easier to control the true false state if its in one place
  - Second and really the only reason  is because if I put Announcement Banner in the individual components 11 test fail in the site-header. 

Let me know if you think this should change.