### PR TITLE
FDG-8391 added back the ()

### DIFF
--- a/src/layouts/explainer/heros/national-deficit/national-deficit-hero.spec.js
+++ b/src/layouts/explainer/heros/national-deficit/national-deficit-hero.spec.js
@@ -29,7 +29,7 @@ describe('National Deficit Hero', () => {
     expect(await getByText('fiscal year (FY)', { exact: false })).toBeInTheDocument();
     expect(await getByText('2022', { exact: false })).toBeInTheDocument();
     expect(await getByText('government has spent $515 billion', { exact: false })).toBeInTheDocument();
-    expect(await getByText('period last year Oct 2020 - Jun 2021', { exact: false })).toBeInTheDocument();
+    expect(await getByText('period last year (Oct 2020 - Jun 2021)', { exact: false })).toBeInTheDocument();
   });
 });
 

--- a/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
+++ b/src/layouts/explainer/heros/national-deficit/national-deficit-hero.tsx
@@ -93,8 +93,8 @@ const NationalDeficitHero = (): ReactElement => {
     <>
     {deficitStatus !== 'not changed' ? (
       <p>
-        Compared to the national deficit of ${desktopPriorDeficit} for the same period last year {' '}
-        {getFootNotesDateRange(previousFiscalYear, previousCalendarYear, currentRecordMonth)}, our national deficit has {deficitStatus} by $
+        Compared to the national deficit of ${desktopPriorDeficit} for the same period last year (
+        {getFootNotesDateRange(previousFiscalYear, previousCalendarYear, currentRecordMonth)}), our national deficit has {deficitStatus} by $
         {deficitDif}.
       </p>
     )


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-8391

TEST: no coverage change. 

This PR was made per the request of Lindsey for an error in the Mac. 

https://data-transparency-bfs.slack.com/archives/CRFQA2DM1/p1705002562285659