### PR TITLE
FDG-8741 DTS Dataset Date Selections Don't Update Data Table

### DIFF
--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -124,6 +124,12 @@ const DataTable: FunctionComponent<DataTableProps> = ({
     }
   }, [detailViewState]);
 
+  useEffect(() => {
+    if (rawData) {
+      setTableData(rawData);
+    }
+  }, [rawData]);
+
   const allColumns = React.useMemo(() => {
     const hideCols = selectedDetailView ? detailViewAPI.hideColumns : hideColumns;
 


### PR DESCRIPTION
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-8741
Coverage: 90.77%

This bug was present on small tables on large datasets. So please feel free to test multiples of those (DTS Op Cash Balance, 120 Day Delinquent Debt Referral Compliance Report, etc) 