### PR TITLE
FDG-8829 In Learn More section TreasuryDirect spelled wrong

### DIFF
--- a/src/layouts/explainer/sections/treasury-savings-bonds/learn-more/learn-more.tsx
+++ b/src/layouts/explainer/sections/treasury-savings-bonds/learn-more/learn-more.tsx
@@ -6,9 +6,9 @@ const LearnMore: FunctionComponent = () => {
     <>
       <p>
         Today, individuals can buy Series I and Series EE bonds online through{' '}
-        <CustomLink url="https://www.treasurydirect.gov/savings-bonds/buy-a-bond/">TreasuyDirect.gov</CustomLink>. TreasuryDirect also offers a
-        feature called <CustomLink url="https://treasurydirect.gov/savings-bonds/treasury-hunt/">Treasure Hunt</CustomLink>, which allows users to
-        search to see if there are unredeemed bonds in their name.
+        <CustomLink url="https://www.treasurydirect.gov/savings-bonds/buy-a-bond/">TreasuryDirect</CustomLink>. TreasuryDirect also offers a feature
+        called <CustomLink url="https://treasurydirect.gov/savings-bonds/treasury-hunt/">Treasure Hunt</CustomLink>, which allows users to search to
+        see if there are unredeemed bonds in their name.
       </p>
     </>
   );


### PR DESCRIPTION
[FDG-8829](https://federal-spending-transparency.atlassian.net/browse/FDG-8829)

Correcting link:
TreasuyDirect.gov -> TreasuryDirect

- removing .gov
- adding "r" to "treasury"