### PR TITLE
FDG-8799 update summary header font size to 14px/0.875rem

### DIFF
--- a/src/components/dataset-data/table-section-container/summary-table/summary-table.module.scss
+++ b/src/components/dataset-data/table-section-container/summary-table/summary-table.module.scss
@@ -24,7 +24,7 @@
   width: 10rem;
   .sectionHeader {
     font-weight: $semi-bold-weight;
-    font-size: $font-size-12;
+    font-size: $font-size-14;
     margin-bottom: 0.25rem;
   }
   margin-bottom: 1.5rem;


### PR DESCRIPTION
[**Jira**](https://federal-spending-transparency.atlassian.net/browse/FDG-8799)

**Test Coverage** 
All files (line %): 90.36%
![image](https://github.com/fedspendingtransparency/fiscal-data/assets/159341849/d2396c11-7108-4343-a6c3-2f3086ac53d4)
