### PR TITLE
FDG-8988 When user clicks on the XML file it is opening the file

### DIFF
--- a/src/components/links/custom-link/custom-link.tsx
+++ b/src/components/links/custom-link/custom-link.tsx
@@ -109,6 +109,13 @@ const CustomLink: FunctionComponent<CustomLinkProps> = ({
         </a>
       );
 
+    case urlOrHref.endsWith('.xml'):
+      return (
+        <a href={urlOrHref} className="primary" download data-testid={dataTestId || 'download-link'}>
+          {children}
+        </a>
+      );
+
     default:
       return (
         <Link


### PR DESCRIPTION
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-8988
Note: XML Files should download like pdfs from the custom link