### PR TITLE
FDG 8904 Links in Glossary Slideout Are Not Displaying as Clickable Links

### DIFF
--- a/src/components/glossary/glossary-definition/glossary-definition.tsx
+++ b/src/components/glossary/glossary-definition/glossary-definition.tsx
@@ -9,8 +9,8 @@ interface IGlossaryDefinition {
 }
 
 const GlossaryDefinition: FunctionComponent<IGlossaryDefinition> = ({ glossaryTerm }) => {
-  const { term, definition } = glossaryTerm;
-  const definitionDisplay = applyFormatting(definition, term);
+  const { term } = glossaryTerm;
+  const definitionDisplay = applyFormatting(glossaryTerm);
   return (
     <div className={definitionContainer}>
       <span className={termName}>{term}</span>

--- a/src/helpers/glossary-helper/glossary-lookup.js
+++ b/src/helpers/glossary-helper/glossary-lookup.js
@@ -49,7 +49,7 @@ export const glossaryLookup = (value, glossary, page) => {
     if (customFormat) {
       definitionFormatted = applyFormatting(entry);
     }
-    if (entry.url_display && entry.url_path) {
+    if (!customFormat && entry.url_display && entry.url_path) {
       definitionFormatted = urlFormat(entry, definitionFormatted);
     }
   }

--- a/src/helpers/glossary-helper/glossary-lookup.js
+++ b/src/helpers/glossary-helper/glossary-lookup.js
@@ -11,10 +11,12 @@ const customFormatting = {
   },
 };
 
-export const applyFormatting = (definition, term) => {
+export const applyFormatting = entry => {
   let count = 0;
-  const customFormat = customFormatting[term];
-  return reactStringReplace(definition, customFormat?.text, (match, index) => {
+  const customFormat = customFormatting[entry.term];
+  let definition = entry.definition;
+
+  definition = reactStringReplace(definition, customFormat?.text, (match, index) => {
     count = count + 1;
     if (count === customFormat.index + 1) {
       if (customFormat.format === 'underline') {
@@ -23,6 +25,12 @@ export const applyFormatting = (definition, term) => {
     }
     return match;
   });
+
+  if (entry.url_display && entry.url_path) {
+    definition = urlFormat(entry, definition);
+  }
+
+  return definition;
 };
 
 export const glossaryLookup = (value, glossary, page) => {
@@ -39,12 +47,10 @@ export const glossaryLookup = (value, glossary, page) => {
     definitionFormatted = definition;
     const customFormat = customFormatting[glossaryTerm];
     if (customFormat) {
-      definitionFormatted = applyFormatting(definitionFormatted, glossaryTerm);
+      definitionFormatted = applyFormatting(entry);
     }
     if (entry.url_display && entry.url_path) {
-      definitionFormatted = reactStringReplace(definitionFormatted, entry.url_display, match => {
-        return <CustomLink url={entry.url_path}>{match}</CustomLink>;
-      });
+      definitionFormatted = urlFormat(entry, definitionFormatted);
     }
   }
 
@@ -53,4 +59,10 @@ export const glossaryLookup = (value, glossary, page) => {
     definition: definitionFormatted ? definitionFormatted : definition,
     slug: slug,
   };
+};
+
+export const urlFormat = (entry, definitionFormatted) => {
+  return reactStringReplace(definitionFormatted, entry.url_display, match => {
+    return <CustomLink url={entry.url_path}>{match}</CustomLink>;
+  });
 };


### PR DESCRIPTION
[Jira](https://federal-spending-transparency.atlassian.net/browse/FDG-8904)

**Test Coverage**
All files (% lines): 90.27% 
![image](https://github.com/fedspendingtransparency/fiscal-data/assets/159341849/daabd0c2-1f43-49a5-ac7a-bb36d8c1bba4)
glossary-lookup.js: 93.93%
![image](https://github.com/fedspendingtransparency/fiscal-data/assets/159341849/d723e92d-1d84-45be-9efe-84c0704c7f42)
glossary-definition.tsx: 100%
![image](https://github.com/fedspendingtransparency/fiscal-data/assets/159341849/e815db78-9dca-4885-8833-e2cab5e48fba)
