### PR TITLE
FDG-8970- Inflation toggle not appearing as expected for the Savings Bonds Sold by Type Over Time chart

### DIFF
--- a/src/layouts/explainer/sections/treasury-savings-bonds/purchase-of-savings-bonds/savings-bonds-sold-by-type-chart/inflation-toogle/inflation-toggle.tsx
+++ b/src/layouts/explainer/sections/treasury-savings-bonds/purchase-of-savings-bonds/savings-bonds-sold-by-type-chart/inflation-toogle/inflation-toggle.tsx
@@ -11,6 +11,7 @@ const StyledSwitch = styled((props: SwitchProps) => <Switch focusVisibleClassNam
   '& .MuiSwitch-switchBase': {
     padding: 0,
     margin: 2,
+    color: '#fff !important',
     transitionDuration: '300ms',
     '&.Mui-focusVisible': {
       '.MuiSwitch-thumb': {
@@ -19,7 +20,7 @@ const StyledSwitch = styled((props: SwitchProps) => <Switch focusVisibleClassNam
     },
     '&.Mui-checked': {
       transform: 'translateX(21px)',
-      color: '#fff',
+      color: '#fff !important',
       '& + .MuiSwitch-track': {
         backgroundColor: treasurySavingsBondsExplainerSecondary,
         opacity: 1,
@@ -30,24 +31,23 @@ const StyledSwitch = styled((props: SwitchProps) => <Switch focusVisibleClassNam
   '& .MuiSwitch-thumb': {
     width: 16,
     height: 16,
-    border: '2px solid #864381',
+    border: '2px solid #864381 !important',
   },
   '& .MuiSwitch-track': {
     borderRadius: 24 / 2,
     backgroundColor: '#e2bee4',
     opacity: 1,
+    position: 'absolute !important',
   },
 }));
 
-const InflationToggle: FunctionComponent<{ 
-  onToggle: (isToggled: boolean) => void, 
-  isInflationAdjusted: boolean 
+const InflationToggle: FunctionComponent<{
+  onToggle: (isToggled: boolean) => void;
+  isInflationAdjusted: boolean;
 }> = ({ onToggle, isInflationAdjusted }) => {
-
   const handleToggle = () => {
-
     onToggle(!isInflationAdjusted);
-  }
+  };
 
   return (
     <StyledSwitch


### PR DESCRIPTION
[FDG-8970](https://federal-spending-transparency.atlassian.net/jira/software/c/projects/FDG/boards/44?quickFilter=414&selectedIssue=FDG-8970)

There were no change in the test coverage all MUI styling updates. 


The issue was mostly the position changing to relative for some reason. So I set it to absolute !important. I also had to change around the the styling a little bit to get the color to stay #fff. Noticed that changed as well. 