### PR TITLE
FDG-8985 Improve api-utils-helper.js test coverage related to downloads / download params building

### DIFF
--- a/src/utils/api-utils-helper.js
+++ b/src/utils/api-utils-helper.js
@@ -147,19 +147,10 @@ const buildDownloadObject = (api, dateRange, fileType, userFilter, tableColumnSo
   };
 };
 
-export const buildTableColumnSortParams = (sortData, apiSortParams) => {
-  let tableColumnFields = '&fields=';
+export const buildTableColumnSortParams = (sortData) => {
   let tableColumnSort = '';
-  let tableColumnFilter = '';
-  let defaultParamsWithColumnSelect = [];
+
   sortData.forEach(column => {
-    if (!column.allColumnsSelected) {
-      if (tableColumnFields === '&fields=') {
-        tableColumnFields += `${column.id}`;
-      } else {
-        tableColumnFields += `,${column.id}`;
-      }
-    }
     if (column.sorted !== false) {
       if (column.sorted === 'asc') {
         tableColumnSort += `+${column.id}`;
@@ -167,28 +158,10 @@ export const buildTableColumnSortParams = (sortData, apiSortParams) => {
         tableColumnSort += `-${column.id}`;
       }
     }
-    if (column.filterValue !== undefined) {
-      tableColumnFilter += `,${column.id}:in:(${[...new Set(column.rowValues)].join(',')})`;
-    }
   });
-  // If the user has engaged the column select, apply the default sort params to the applicable selected columns
-  if (tableColumnFields !== '&fields=') {
-    const fieldsAsArray = tableColumnFields.replace('&fields=', '').split(',');
-    const defaultSortParamsAsArray = apiSortParams.split(',');
-    defaultSortParamsAsArray.filter(element => {
-      fieldsAsArray.forEach(field => {
-        if (element.includes(field)) {
-          defaultParamsWithColumnSelect.push(element);
-        }
-      });
-    });
-    defaultParamsWithColumnSelect = defaultParamsWithColumnSelect.join(',');
-  }
+
   return {
-    fields: tableColumnFields,
-    sort: tableColumnSort,
-    filter: tableColumnFilter,
-    defaultParamsWithColumnSelect: defaultParamsWithColumnSelect,
+    sort: tableColumnSort
   };
 };
 

--- a/src/utils/api-utils-helper.spec.js
+++ b/src/utils/api-utils-helper.spec.js
@@ -142,4 +142,34 @@ describe('API Utils Helper', () => {
 
     expect(helpers.buildDownloadRequestArray(apiParams, dateRange, fileType)).toStrictEqual(returnObj);
   });
+
+  it('if primary date field is filtered at the table level and it is filtered before the start date or after the end date of the API date field filter, then constrain the download params for that filter to the API date field', () => {
+    const api = { apiId: 1, dateField: 'record_date' };
+    const dateRange = { from: '2021-01-01', to: '2021-12-31' };
+    const fileType = 'csv';
+
+    const tableColumnSortDataAfter = [
+      {
+        allColumnsSelected: true,
+        downloadFilter: false,
+        filterValue: ['2021-01-01', '2022-01-01'],
+        id: 'record_date',
+      },
+    ];
+
+    const res1 = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, tableColumnSortDataAfter, null);
+    expect(res1.params).toContain('record_date:lte:2021-12-31');
+
+    const tableColumnSortDataBefore = [
+      {
+        allColumnsSelected: true,
+        downloadFilter: false,
+        filterValue: ['2020-01-01', '2021-12-31'],
+        id: 'record_date',
+      },
+    ];
+
+    const res2 = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, tableColumnSortDataBefore, null);
+    expect(res2.params).toContain('record_date:gte:2021-01-01');
+  });
 });

--- a/src/utils/api-utils-helper.spec.js
+++ b/src/utils/api-utils-helper.spec.js
@@ -260,4 +260,51 @@ describe('API Utils Helper', () => {
     const res = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, tableColumnSortData, null);
     expect(res.params).toContain('text:in:(some,text)');
   });
+
+  it('when a user filters is present it is added to the download filters param', () => {
+    const api = { apiId: 1, dateField: 'record_date', userFilter: { field: 'country_currency' } };
+    const dateRange = { from: '2022-01-01', to: '2022-12-31' };
+    const fileType = 'csv';
+    const userFilter = {
+      label: 'euro',
+      value: 'euro',
+    };
+    const tableColumnSortData = [
+      {
+        allColumnsSelected: false,
+        sorted: false,
+        downloadFilter: true,
+        filterValue: ['sometext'],
+        rowValues: ['some', 'text'],
+        id: 'text',
+      },
+    ];
+
+    const res = unitTestObjects.buildDownloadObject(api, dateRange, fileType, userFilter, tableColumnSortData, null);
+    expect(res.params).toContain('country_currency:eq:euro');
+  });
+
+  it('when a detail view filter is present it is added to the download filters param', () => {
+    const api = { apiId: 1, dateField: 'record_date' };
+    const dateRange = { from: '2022-01-01', to: '2022-12-31' };
+    const fileType = 'csv';
+    const detailViewFilter = {
+      field: 'cusip',
+      value: '1234',
+      label: 'CUSIP',
+    };
+    const tableColumnSortData = [
+      {
+        allColumnsSelected: false,
+        sorted: false,
+        downloadFilter: true,
+        filterValue: ['sometext'],
+        rowValues: ['some', 'text'],
+        id: 'text',
+      },
+    ];
+
+    const res = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, tableColumnSortData, detailViewFilter);
+    expect(res.params).toContain('cusip:eq:1234');
+  });
 });

--- a/src/utils/api-utils-helper.spec.js
+++ b/src/utils/api-utils-helper.spec.js
@@ -308,6 +308,15 @@ describe('API Utils Helper', () => {
     expect(res.params).toContain('cusip:eq:1234');
   });
 
+  it('we have an empty tableColumnSortData', () => {
+    const api = { apiId: 1, dateField: 'record_date' };
+    const dateRange = { from: '2022-01-01', to: '2022-12-31' };
+    const fileType = 'csv';
+
+    const res = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, null, null);
+    expect(res.params).not.toContain('&fields=');
+  });
+
   it('buildTableColumnSortParams returns sorted columns info', () => {
     const tableColumnSortData = [
       {
@@ -334,7 +343,5 @@ describe('API Utils Helper', () => {
 
     const res2 = helpers.buildTableColumnSortParams(tableColumnSortData2);
     expect(res2.sort).toEqual('+record_date');
-
   });
-
 });

--- a/src/utils/api-utils-helper.spec.js
+++ b/src/utils/api-utils-helper.spec.js
@@ -307,4 +307,34 @@ describe('API Utils Helper', () => {
     const res = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, tableColumnSortData, detailViewFilter);
     expect(res.params).toContain('cusip:eq:1234');
   });
+
+  it('buildTableColumnSortParams returns sorted columns info', () => {
+    const tableColumnSortData = [
+      {
+        allColumnsSelected: false,
+        sorted: 'desc',
+        downloadFilter: false,
+        filterValue: ['2022-01-01', '2022-01-02', '2022-01-03', '2022-01-04', '2022-01-05'],
+        id: 'record_date',
+      },
+    ];
+
+    const res = helpers.buildTableColumnSortParams(tableColumnSortData);
+    expect(res.sort).toEqual('-record_date');
+
+    const tableColumnSortData2 = [
+      {
+        allColumnsSelected: false,
+        sorted: 'asc',
+        downloadFilter: false,
+        filterValue: ['2022-01-01', '2022-01-02', '2022-01-03', '2022-01-04', '2022-01-05'],
+        id: 'record_date',
+      },
+    ];
+
+    const res2 = helpers.buildTableColumnSortParams(tableColumnSortData2);
+    expect(res2.sort).toEqual('+record_date');
+
+  });
+
 });

--- a/src/utils/api-utils-helper.spec.js
+++ b/src/utils/api-utils-helper.spec.js
@@ -212,8 +212,26 @@ describe('API Utils Helper', () => {
     ];
 
     const res = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, tableColumnSortData, null);
-    console.log('res', res);
     expect(res.params).toContain('sort=+record_date'); // confirming we sort properly
     expect(res.params).toContain('fields=record_date'); // confirming it's been mirrored to fields without sort direction
+  });
+
+  it('fields param contains all columns from sort param without the sort directions when receiving sort direction from api', () => {
+    const api = { apiId: 1, dateField: 'record_date' };
+    const dateRange = { from: '2022-01-01', to: '2022-12-31' };
+    const fileType = 'csv';
+    const tableColumnSortData = [
+      {
+        allColumnsSelected: false,
+        sorted: false,
+        downloadFilter: false,
+        filterValue: ['2022-01-01', '2022-01-02', '2022-01-03', '2022-01-04', '2022-01-05'],
+        id: 'record_date',
+      },
+    ];
+
+    const res = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, tableColumnSortData, null);
+    expect(res.params).toContain('sort=-record_date'); // confirming we sort properly
+    expect(res.params).toContain('fields=record_date');
   });
 });

--- a/src/utils/api-utils-helper.spec.js
+++ b/src/utils/api-utils-helper.spec.js
@@ -241,4 +241,23 @@ describe('API Utils Helper', () => {
     expect(res.params).toContain('sort=-record_date');
     expect(res.params).toContain('fields=record_date,name');
   });
+
+  it('when filtering a column, filter values are included in download params', () => {
+    const api = { apiId: 1, dateField: 'record_date' };
+    const dateRange = { from: '2022-01-01', to: '2022-12-31' };
+    const fileType = 'csv';
+    const tableColumnSortData = [
+      {
+        allColumnsSelected: false,
+        sorted: false,
+        downloadFilter: true,
+        filterValue: ['sometext'],
+        rowValues: ['some', 'text'],
+        id: 'text',
+      },
+    ];
+
+    const res = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, tableColumnSortData, null);
+    expect(res.params).toContain('text:in:(some,text)');
+  });
 });

--- a/src/utils/api-utils-helper.spec.js
+++ b/src/utils/api-utils-helper.spec.js
@@ -182,6 +182,12 @@ describe('API Utils Helper', () => {
         allColumnsSelected: true,
         downloadFilter: false,
         filterValue: ['2022-01-01', '2022-01-02', '2022-01-03', '2022-01-04', '2022-01-05'],
+        id: 'record_date',
+      },
+      {
+        allColumnsSelected: true,
+        downloadFilter: false,
+        filterValue: ['2022-01-01', '2022-01-02', '2022-01-03', '2022-01-04', '2022-01-05'],
         id: 'original_auction_date',
       },
     ];

--- a/src/utils/api-utils-helper.spec.js
+++ b/src/utils/api-utils-helper.spec.js
@@ -228,10 +228,17 @@ describe('API Utils Helper', () => {
         filterValue: ['2022-01-01', '2022-01-02', '2022-01-03', '2022-01-04', '2022-01-05'],
         id: 'record_date',
       },
+      {
+        allColumnsSelected: false,
+        sorted: false,
+        downloadFilter: false,
+        filterValue: ['John Doe'],
+        id: 'name',
+      },
     ];
 
     const res = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, tableColumnSortData, null);
-    expect(res.params).toContain('sort=-record_date'); // confirming we sort properly
-    expect(res.params).toContain('fields=record_date');
+    expect(res.params).toContain('sort=-record_date');
+    expect(res.params).toContain('fields=record_date,name');
   });
 });

--- a/src/utils/api-utils-helper.spec.js
+++ b/src/utils/api-utils-helper.spec.js
@@ -172,4 +172,22 @@ describe('API Utils Helper', () => {
     const res2 = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, tableColumnSortDataBefore, null);
     expect(res2.params).toContain('record_date:gte:2021-01-01');
   });
+
+  it('applies date filters for datasets where extra date filters can be applied in table', () => {
+    const api = { apiId: 1, dateField: 'record_date' };
+    const dateRange = { from: '2022-01-01', to: '2022-12-31' };
+    const fileType = 'csv';
+    const tableColumnSortData = [
+      {
+        allColumnsSelected: true,
+        downloadFilter: false,
+        filterValue: ['2022-01-01', '2022-01-02', '2022-01-03', '2022-01-04', '2022-01-05'],
+        id: 'original_auction_date',
+      },
+    ];
+
+    const res = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, tableColumnSortData, null);
+    expect(res.params).toContain('original_auction_date:gte:2022-01-01');
+    expect(res.params).toContain('original_auction_date:lte:2022-01-05');
+  });
 });

--- a/src/utils/api-utils-helper.spec.js
+++ b/src/utils/api-utils-helper.spec.js
@@ -196,4 +196,24 @@ describe('API Utils Helper', () => {
     expect(res.params).toContain('original_auction_date:gte:2022-01-01');
     expect(res.params).toContain('original_auction_date:lte:2022-01-05');
   });
+
+  it('fields param contains all columns from sort param without the sort directions', () => {
+    const api = { apiId: 1, dateField: 'record_date' };
+    const dateRange = { from: '2022-01-01', to: '2022-12-31' };
+    const fileType = 'csv';
+    const tableColumnSortData = [
+      {
+        allColumnsSelected: false,
+        sorted: 'asc',
+        downloadFilter: false,
+        filterValue: ['2022-01-01', '2022-01-02', '2022-01-03', '2022-01-04', '2022-01-05'],
+        id: 'record_date',
+      },
+    ];
+
+    const res = unitTestObjects.buildDownloadObject(api, dateRange, fileType, null, tableColumnSortData, null);
+    console.log('res', res);
+    expect(res.params).toContain('sort=+record_date'); // confirming we sort properly
+    expect(res.params).toContain('fields=record_date'); // confirming it's been mirrored to fields without sort direction
+  });
 });

--- a/src/utils/api-utils.js
+++ b/src/utils/api-utils.js
@@ -109,7 +109,7 @@ export const pagedDatatableRequest = async (table, from, to, selectedPivot, page
   let tableColumnSort = '';
   let tableColumnSortParams;
   if (tableColumnSortData) {
-    tableColumnSortParams = buildTableColumnSortParams(tableColumnSortData, sortParam);
+    tableColumnSortParams = buildTableColumnSortParams(tableColumnSortData);
     tableColumnSort = tableColumnSortParams.sort;
   }
 
@@ -124,7 +124,7 @@ export const calculatePercentage = (data) => {
   if(!Array.isArray(data)){
     return[];
   }
-  const total = data.reduce((acc, curr) => acc + curr.value, 
+  const total = data.reduce((acc, curr) => acc + curr.value,
   0);
   return data.map(item => ({
     ...item,


### PR DESCRIPTION
**Description**

Increasing test coverage around downloads and download param building. 
Previous coverage: 42.34%
<img width="410" alt="image" src="https://github.com/fedspendingtransparency/fiscal-data/assets/159341849/27f159c0-c9eb-4bf9-a93d-06a8e6fd716b">

[**Jira Story**](https://federal-spending-transparency.atlassian.net/browse/FDG-8985)

**Test Coverage**
All files (% lines): 90.66% 
![image](https://github.com/fedspendingtransparency/fiscal-data/assets/159341849/68b61553-2f97-42ec-99ad-076659e85b43)
api-utils-helper.js: 100%
![image](https://github.com/fedspendingtransparency/fiscal-data/assets/159341849/0ecabd3a-8133-4657-8aec-fc4fedc5dec7)

**Note to devs:** deleted unused code from api-utils-helper.js. This was caught while writing tests for the file. 
