### PR TITLE
FDG-9279 When downloading a file, direct download should not apply to this table because it is a large data table

### DIFF
--- a/src/components/data-table/data-table-footer/data-table-footer.tsx
+++ b/src/components/data-table/data-table-footer/data-table-footer.tsx
@@ -25,7 +25,7 @@ const DataTableFooter: FunctionComponent<IDataTableFooter> = ({
   const setTableRowSizeData = useSetRecoilState(tableRowLengthState);
   useEffect(() => {
     setFilteredRowLength(table.getFilteredRowModel().rows.length);
-    manualPagination ? setTableRowSizeData(pagingProps.maxRows) : setTableRowSizeData(table.getFilteredRowModel().rows.length);
+    setTableRowSizeData(manualPagination ? null : table.getFilteredRowModel().rows.length);
   }, [table.getFilteredRowModel(), pagingProps]);
 
   const visibleRows = table => {

--- a/src/components/download-wrapper/download-wrapper.jsx
+++ b/src/components/download-wrapper/download-wrapper.jsx
@@ -187,7 +187,7 @@ const DownloadWrapper = ({
   }, [globalDisableDownloadButton]);
 
   const determineDirectDownload = () => {
-    if (tableSize <= REACT_TABLE_MAX_NON_PAGINATED_SIZE) {
+    if (tableSize !== null && tableSize <= REACT_TABLE_MAX_NON_PAGINATED_SIZE) {
       return (
         <>
           <DownloadItemButton


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-9279

No change in coverage