### PR TITLE
FDG-9308 Hover tooltip is not working on the Published Date drop down arrow

### DIFF
--- a/src/components/select-control/select-control.module.scss
+++ b/src/components/select-control/select-control.module.scss
@@ -21,6 +21,7 @@
     position: absolute;
     right: 0.6rem;
     top: 0.7875rem;
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-9308

No change in coverage