### PR TITLE
FDG-8682 New Dataset Created in UAT - Treasury Securities Buybacks Announcements/Results

### DIFF
--- a/env/uat.js
+++ b/env/uat.js
@@ -57,28 +57,10 @@ module.exports = {
       relatedDatasets: ['015-BFS-2014Q3-045', '015-BFS-2014Q3-050', '015-BFS-2014Q3-049', '015-BFS-2014Q1-14', '015-BFS-2014Q3-048'],
       currentDateButton: 'byDay',
       "detailView": {
-        "apiId": 316,
-        "field": "operation_date",
-        "label": "Operation Date",
-        // "dateRangeLockCopy": "To filter data by date range, select a CUSIP from the table below.",
-        "summaryTableFields": [
-          "operation_date",
-          "operation_start_time_est",
-          "operation_close_time_est",
-          "settlement_date"
-        ],
-        "selectColumns": [
-          "operation_date",
-          "operation_start_time_est",
-          "operation_close_time_est",
-          "settlement_date"
-        ]
-      },
-      "detailView": {
         "apiId": 317,
         "field": "operation_date",
         "label": "Operation Date",
-        // "dateRangeLockCopy": "To filter data by date range, select a CUSIP from the table below.",
+        "dateRangeLockCopy": "To filter data by date range, select a CUSIP from the table below.",
         "summaryTableFields": [
           "operation_date",
           "operation_start_time_est",
@@ -86,11 +68,12 @@ module.exports = {
           "settlement_date"
         ],
         "selectColumns": [
-          "operation_date",
-          "operation_start_time_est",
-          "operation_close_time_est",
-          "settlement_date"
-        ]
+          "cusip_nbr",
+          "coupon_rate_pct",
+          "maturity_date",
+          "par_amt_accepted",
+          "weighted_avg_accepted_price"
+        ],
       }
     },
   },

--- a/env/uat.js
+++ b/env/uat.js
@@ -46,6 +46,53 @@ module.exports = {
       relatedDatasets: ['015-BFS-2014Q3-098', '015-BFS-2014Q3-051'],
       currentDateButton: 'byMonth',
     },
+    '015-BFS-2024Q2-001': {
+      slug: '/treasury-securities-buybacks/',
+      seoConfig: {
+        pageTitle: 'Treasury Securities Buybacks',
+        description:
+          'The Treasury Securities Buybacks dataset contains data related to the U.S. Treasury\'s buyback operations.',
+      },
+      topics: ['debt', 'auctions'],
+      relatedDatasets: ['015-BFS-2014Q3-045', '015-BFS-2014Q3-050', '015-BFS-2014Q3-049', '015-BFS-2014Q1-14', '015-BFS-2014Q3-048'],
+      currentDateButton: 'byDay',
+      "detailView": {
+        "apiId": 316,
+        "field": "operation_date",
+        "label": "Operation Date",
+        // "dateRangeLockCopy": "To filter data by date range, select a CUSIP from the table below.",
+        "summaryTableFields": [
+          "operation_date",
+          "operation_start_time_est",
+          "operation_close_time_est",
+          "settlement_date"
+        ],
+        "selectColumns": [
+          "operation_date",
+          "operation_start_time_est",
+          "operation_close_time_est",
+          "settlement_date"
+        ]
+      },
+      "detailView": {
+        "apiId": 317,
+        "field": "operation_date",
+        "label": "Operation Date",
+        // "dateRangeLockCopy": "To filter data by date range, select a CUSIP from the table below.",
+        "summaryTableFields": [
+          "operation_date",
+          "operation_start_time_est",
+          "operation_close_time_est",
+          "settlement_date"
+        ],
+        "selectColumns": [
+          "operation_date",
+          "operation_start_time_est",
+          "operation_close_time_est",
+          "settlement_date"
+        ]
+      }
+    },
   },
   ADDITIONAL_ENDPOINTS: {
     '160': {
@@ -190,6 +237,22 @@ module.exports = {
       downloadName: 'FIP_PO_Total_Outstanding_Inflation_Comp',
       alwaysSortWith: ['-record_date,account_nbr,src_line_nbr'],
       selectColumn: [],
+    },
+    // Buybacks
+    '316': {
+      endpoint: 'v1/accounting/od/buybacks_operations',
+      dateField: 'operation_date',
+      downloadName: 'Buybacks_Operations',
+      alwaysSortWith: ['-operation_date'],
+      selectColumn: ['operation_date, operation_start_time_est, operation_close_time_est, settlement_date, tentative_ann_pdf, tentative_ann_xml, final_ann_pdf, final_ann_xml, results_pdf, results_xml, special_ann_pdf'],
+    },
+    // Buybacks
+    '317': {
+      endpoint: 'v1/accounting/od/buybacks_security_details',
+      dateField: 'operation_date',
+      downloadName: 'Buybacks_Security_Details',
+      alwaysSortWith: ['-operation_date,maturity_date'],
+      selectColumn: ['cusip_nbr, coupon_rate_pct, maturity_date, par_amt_accepted, weighted_avg_accepted_price'],
     },
   },
 };

--- a/env/uat.js
+++ b/env/uat.js
@@ -60,7 +60,7 @@ module.exports = {
         "apiId": 317,
         "field": "operation_date",
         "label": "Operation Date",
-        "dateRangeLockCopy": "To filter data by date range, select a CUSIP from the table below.",
+        "dateRangeLockCopy": "To filter data by date range, select a Operation Date from the table below.",
         "summaryTableFields": [
           "operation_date",
           "operation_start_time_est",

--- a/src/components/data-table/data-table-helper.tsx
+++ b/src/components/data-table/data-table-helper.tsx
@@ -20,7 +20,7 @@ const customFormat = (stringValue, decimalPlaces) => {
   return returnString;
 };
 
-const tablesWithPublishedReportLinks = ['Treasury Securities Auctions Data', 'Reference CPI Numbers and Daily Index Ratios Summary Table'];
+const tablesWithPublishedReportLinks = ['Treasury Securities Auctions Data', 'Reference CPI Numbers and Daily Index Ratios Summary Table', 'Buybacks Operations'];
 
 const publishedReportsLinkWrapper = (url, value) => {
   return (
@@ -58,7 +58,25 @@ const publishedReportsLinksProcessor = (tableName, property, value) => {
     } else {
       return value;
     }
-  } else {
+  }
+  if (tableName === 'Buybacks Operations') {
+    switch(property) {
+      case 'results_pdf':
+      case 'results_xml':
+        return publishedReportsLinkWrapper(`/static-data/published-reports/buybacks/result/${value}`, value);
+      case 'final_ann_pdf':
+      case 'final_ann_xml':
+        return publishedReportsLinkWrapper(`/static-data/published-reports/buybacks/announcement/${value}`, value);
+      case 'tentative_ann_xml':
+      case 'tentative_ann_pdf':
+        return publishedReportsLinkWrapper(`/static-data/published-reports/buybacks/tentative/${value}`, value);
+      case 'special_ann_pdf':
+        return publishedReportsLinkWrapper(`/static-data/published-reports/buybacks/special-announcement/${value}`, value);
+      default:
+        return value;
+    }
+  }
+  else {
     return value;
   }
 };


### PR DESCRIPTION
**Jira**
https://federal-spending-transparency.atlassian.net/browse/FDG-8682

**Test Coverage**
all files (% lines): 90.86

