### PR TITLE
FDG-8648 Remove Specific Columns from Default View on the Historical Debt Outstanding Dataset

### DIFF
--- a/src/transform/endpointConfig.js
+++ b/src/transform/endpointConfig.js
@@ -1188,6 +1188,7 @@ const endpointConfig = {
     endpoint: 'v2/accounting/od/debt_outstanding',
     dateField: 'record_date',
     downloadName: 'HstDebt',
+    selectColumns: ['record_date', 'debt_outstanding_amt'],
   },
   '146': {
     endpoint: 'v2/accounting/od/avg_interest_rates',


### PR DESCRIPTION
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-8648
No change in coverage