### PR TITLE
FDG-9635 UTF - All Data Table Selection - Do Not Retain Acct Selection

### DIFF
--- a/src/components/filter-download-container/user-filter/user-filter.tsx
+++ b/src/components/filter-download-container/user-filter/user-filter.tsx
@@ -3,8 +3,6 @@ import { userFilterWrapper, filterLabel } from './user-filter.module.scss';
 import NotShownMessage from '../../dataset-data/table-section-container/not-shown-message/not-shown-message';
 import ComboCurrencySelect from '../../combo-select/combo-currency-select/combo-currency-select';
 import DatatableBanner from '../datatable-banner/datatable-banner';
-import { monthFullNames } from '../../../utils/api-utils';
-import { mockSavingsBondLastFiscalYearCurrentMonth } from '../../../layouts/explainer/explainer-test-helper';
 import MonthYearFilter from '../month-year-filter/month-year-filter';
 
 type UserFilterProps = {
@@ -108,7 +106,7 @@ const UserFilter: FunctionComponent<UserFilterProps> = ({
   useEffect(() => {
     establishOptions();
     setSelectedFilterOption(defaultSelection);
-  }, [selectedTable]);
+  }, [selectedTable, allTablesSelected]);
 
   return (
     <>


### PR DESCRIPTION
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-9635

- Took care of case where filter retained selection after selecting all tables and returning to original table selection. 