### PR TITLE
FDG-9521 General Site Updates - Set data table column width to be length of column title

### DIFF
--- a/src/components/data-table/data-table-header/data-table-header.tsx
+++ b/src/components/data-table/data-table-header/data-table-header.tsx
@@ -86,7 +86,7 @@ const DataTableHeader: FunctionComponent<IDataTableHeader> = ({
                   key={header.id}
                   colSpan={header.colSpan}
                   style={{
-                    minWidth: header.id.includes('_date') ? '12.5rem' : header.getSize(),
+                    minWidth: header.getSize(),
                   }}
                 >
                   {header.isPlaceholder ? null : (

--- a/src/components/data-table/data-table-header/date-range-filter/date-range-filter.module.scss
+++ b/src/components/data-table/data-table-header/date-range-filter/date-range-filter.module.scss
@@ -14,6 +14,7 @@
   text-overflow: ellipsis;
   margin-bottom: 10.5px;
   margin-top: 10.5px;
+  margin-right: 5px;
 }
 
 .dateTextBegin {

--- a/src/components/data-table/data-table.module.scss
+++ b/src/components/data-table/data-table.module.scss
@@ -41,7 +41,6 @@ $borderRadius: 5px;
     text-align: center;
     height: 1.875rem;
     padding: 0.25rem 0.5rem 0.75rem;
-    max-width: 10rem;
   }
 
   .tr {


### PR DESCRIPTION
Ticket: https://federal-spending-transparency.atlassian.net/browse/FDG-9521
No change in coverage

Notes:

- After conversation with Kylon, date columns with short column titles can have a minimum width that matches the filter placeholder text so as to not obscure the filter, this means adding 5px of right padding to the filter to ensure the icon isn’t squished with the smaller column size. 
- Columns that have titles shorter then the column width remain as is
- Per 10/1/24 standup conversation, based on the limited solutions, we’ll move forward with setting it so you have the columns default to the width of the titles. Users won’t be able to resize smaller than that but can resize bigger. We’ll potentially explore future options on how to add the ability for a user to resize smaller.