### PR TITLE
FDG-10017 Interest Expense Insight - Split color swatch for "Interest Expense" to display both solid color and stripes

### DIFF
--- a/src/layouts/insight/sections/interest-expense/interest-expense-chart/interest-expense-chart-helper.tsx
+++ b/src/layouts/insight/sections/interest-expense/interest-expense-chart/interest-expense-chart-helper.tsx
@@ -1,4 +1,4 @@
-import { expenseLegend, expenseText, legendContainer, line, rateLegend, rectangle } from './interest-expense-chart.module.scss';
+import { expenseLegend, expenseText, legendContainer, line, rateLegend, rectangle, stripedRectangle } from './interest-expense-chart.module.scss';
 import React, { FunctionComponent, ReactElement } from 'react';
 
 type Tooltip = (object: {
@@ -25,6 +25,7 @@ export const Legend: FunctionComponent = (): ReactElement => {
       <div className={expenseLegend}>
         <span className={expenseText}>Interest Expense</span>
         <div className={rectangle} />
+        <div className={stripedRectangle} />
       </div>
       <div className={rateLegend}>
         <div className={line} />

--- a/src/layouts/insight/sections/interest-expense/interest-expense-chart/interest-expense-chart.module.scss
+++ b/src/layouts/insight/sections/interest-expense/interest-expense-chart/interest-expense-chart.module.scss
@@ -1,5 +1,5 @@
 @import 'src/variables.module';
-$interest-expense-primary: #00796B;
+$interest-expense-primary: #00796b;
 
 .legendContainer {
   display: flex;
@@ -31,6 +31,14 @@ $interest-expense-primary: #00796B;
   background: $interest-expense-primary;
   margin-left: 0.5rem;
   margin-top: 0.2rem;
+}
+.stripedRectangle {
+  width: 12px;
+  height: 16px;
+  //background: $interest-expense-primary;
+  margin-top: 0.2rem;
+  background-color: #fff;
+  background-image: repeating-linear-gradient(135deg, transparent, transparent 2px, $interest-expense-primary 0, $interest-expense-primary 5px);
 }
 
 .rateLegend {

--- a/src/layouts/insight/sections/interest-expense/interest-expense-chart/interest-expense-chart.module.scss
+++ b/src/layouts/insight/sections/interest-expense/interest-expense-chart/interest-expense-chart.module.scss
@@ -26,7 +26,7 @@ $interest-expense-primary: #00796b;
 }
 
 .rectangle {
-  width: 24px;
+  width: 12px;
   height: 16px;
   background: $interest-expense-primary;
   margin-left: 0.5rem;
@@ -35,7 +35,6 @@ $interest-expense-primary: #00796b;
 .stripedRectangle {
   width: 12px;
   height: 16px;
-  //background: $interest-expense-primary;
   margin-top: 0.2rem;
   background-color: #fff;
   background-image: repeating-linear-gradient(135deg, transparent, transparent 2px, $interest-expense-primary 0, $interest-expense-primary 5px);


### PR DESCRIPTION
[FDG-10017](https://federal-spending-transparency.atlassian.net/browse/FDG-10017)

No change in test: 90.09
interest-expense-chart and chart helper: 100%
