### PR TITLE
FDG-10095 Interest Expense Insight chart is displaying label for the current year 2025. It should only display label for every 2 years

### DIFF
--- a/src/layouts/insight/sections/interest-expense/useGetInterestExpenseData.ts
+++ b/src/layouts/insight/sections/interest-expense/useGetInterestExpenseData.ts
@@ -149,9 +149,7 @@ export const useGetInterestExpenseData = (shouldHaveChartData: boolean, isMobile
             if (!allYears.includes(parseInt(current))) {
               allYears.push(parseInt(current));
             }
-            const filteredYears = isMobile
-              ? allYears.filter((val, i) => i % 4 === 0 || val === parseInt(current))
-              : allYears.filter((val, i) => i % 2 === 0 || val === parseInt(current));
+            const filteredYears = isMobile ? allYears.filter((val, i) => i % 4 === 0) : allYears.filter((val, i) => i % 2 === 0);
 
             setChartXAxisValues(filteredYears);
 


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-10095

no change in testing