### PR TITLE
FDG-10080 API documentation page has Pivoting on the side navigation, but the Pivoting section is deleted on the page

### DIFF
--- a/src/pages/api-documentation/index.jsx
+++ b/src/pages/api-documentation/index.jsx
@@ -211,11 +211,6 @@ const ApiDocumentationPage = ({ location }) => {
       title: 'Aggregation',
     },
     {
-      id: 'examples-pivoting',
-      headingLevel: headingLevel3,
-      title: 'Pivoting',
-    },
-    {
       id: 'examples-multi-dimension-datasets',
       headingLevel: headingLevel3,
       title: 'Multi-dimension Datasets',


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-10080

No change to test coverage