### PR TITLE
FDG-10029 Add Quotes Text Qualifiers to CSV Downloads

### DIFF
--- a/src/components/data-preview/data-preview-data-table/data-preview-data-table.spec.js
+++ b/src/components/data-preview/data-preview-data-table/data-preview-data-table.spec.js
@@ -15,9 +15,14 @@ import {
   mockColumnConfig,
   mockDetailViewColumnConfig,
   mockDetailApiData,
+  mockTableDownloadWithTextQualifier,
+  mockColumnConfigDownloadWithTextQualifier,
 } from '../../data-table/data-table-test-helper';
 import userEvent from '@testing-library/user-event';
 import DataPreviewDataTable from './data-preview-data-table';
+import DataTable from '../../data-table/data-table';
+import { smallTableDownloadDataCSV } from '../../../recoil/smallTableDownloadData';
+import { RecoilObserver } from '../../../utils/test-utils';
 
 describe('react-table', () => {
   const setTableColumnSortData = jest.fn();
@@ -539,6 +544,57 @@ describe('react-table', () => {
         </RecoilRoot>
       );
       expect(getAllByTestId('row')[0].innerHTML).toContain('-$134.100');
+    });
+
+    it('renders with download timestamp enabled', () => {
+      const instance = render(
+        <RecoilRoot>
+          <DataPreviewDataTable
+            rawData={mockTableData}
+            defaultSelectedColumns={defaultColumnsTypeCheckMock}
+            pagingProps={{ itemsPerPage: 10 }}
+            setTableColumnSortData={setTableColumnSortData}
+            shouldPage
+            showPaginationControls
+            setFiltersActive={jest.fn()}
+            columnConfig={mockColumnConfig}
+            setTableSorting={jest.fn()}
+            hasDownloadTimestamp={true}
+            dateRange={{
+              from: '2022-08-31',
+              to: '2024-08-31',
+            }}
+          />
+        </RecoilRoot>
+      );
+      expect(instance).toBeTruthy();
+    });
+
+    it('updates recoil state for csv download with text qualifiers', () => {
+      const setSmallTableDownloadDataCSV = jest.fn();
+      render(
+        <RecoilRoot>
+          <RecoilObserver node={smallTableDownloadDataCSV} onChange={setSmallTableDownloadDataCSV} />
+          <DataPreviewDataTable
+            rawData={mockTableDownloadWithTextQualifier}
+            pagingProps={{ itemsPerPage: 10 }}
+            setTableColumnSortData={setTableColumnSortData}
+            shouldPage
+            showPaginationControls
+            setFiltersActive={jest.fn()}
+            columnConfig={mockColumnConfigDownloadWithTextQualifier}
+            setTableSorting={jest.fn()}
+            dateRange={{
+              from: '2022-08-31',
+              to: '2024-08-31',
+            }}
+          />
+        </RecoilRoot>
+      );
+      expect(setSmallTableDownloadDataCSV).toHaveBeenCalledWith([
+        ['Record Date', 'String Value', 'String Value with Commas'],
+        ['2023-07-12', 'just a normal string', '"comma, separated, list"'],
+      ]);
     });
 
     it('formats FRN Daily Index number values correctly', () => {

--- a/src/components/data-preview/data-preview-data-table/data-preview-data-table.tsx
+++ b/src/components/data-preview/data-preview-data-table/data-preview-data-table.tsx
@@ -201,7 +201,11 @@ const DataPreviewDataTable: FunctionComponent<IDataTableProps> = ({
       setSmallTableJSONData(JSON.stringify({ data: downloadData }));
       setSmallTableXMLData(json2xml(JSON.stringify(xmlData), { compact: true }));
       downloadData = downloadData.map(entry => {
-        return Object.values(entry);
+        const dataWithTextQualifiers = [];
+        Object.values(entry).forEach(val => {
+          dataWithTextQualifiers.push(val.includes(',') ? `"${val}"` : val);
+        });
+        return dataWithTextQualifiers;
       });
       downloadData.unshift(downloadHeaders);
       setSmallTableCSVData(downloadData);

--- a/src/components/data-preview/data-preview-data-table/data-preview-data-table.tsx
+++ b/src/components/data-preview/data-preview-data-table/data-preview-data-table.tsx
@@ -7,7 +7,7 @@ import {
   smallTableDownloadDataXML,
   tableRowLengthState,
 } from '../../../recoil/smallTableDownloadData';
-import { columnsConstructorData, getSortedColumnsData } from '../../data-table/data-table-helper';
+import { columnsConstructorData, constructDateHeader, getSortedColumnsData } from '../../data-table/data-table-helper';
 import { getCoreRowModel, getFilteredRowModel, getPaginationRowModel, getSortedRowModel, Table, useReactTable } from '@tanstack/react-table';
 import { json2xml } from 'xml-js';
 import { overlayContainerNoFooter, rawDataTableContainer } from './data-preview-data-table.module.scss';
@@ -48,6 +48,9 @@ const DataPreviewDataTable: FunctionComponent<IDataTableProps> = ({
   setAllActiveFilters,
   setTableSorting,
   disableDateRangeFilter,
+  datasetName,
+  dateRange,
+  hasDownloadTimestamp,
 }) => {
   const [configOption, setConfigOption] = useState(columnConfig);
   const setSmallTableCSVData = useSetRecoilState(smallTableDownloadDataCSV);
@@ -203,11 +206,15 @@ const DataPreviewDataTable: FunctionComponent<IDataTableProps> = ({
       downloadData = downloadData.map(entry => {
         const dataWithTextQualifiers = [];
         Object.values(entry).forEach(val => {
-          dataWithTextQualifiers.push(val.includes(',') ? `"${val}"` : val);
+          dataWithTextQualifiers.push(val?.includes(',') ? `"${val}"` : val);
         });
         return dataWithTextQualifiers;
       });
       downloadData.unshift(downloadHeaders);
+      if (hasDownloadTimestamp) {
+        const dateHeader = constructDateHeader(datasetName, dateRange);
+        downloadData.unshift(dateHeader);
+      }
       setSmallTableCSVData(downloadData);
     }
   }, [columnVisibility, table.getSortedRowModel(), table.getVisibleFlatColumns()]);

--- a/src/components/data-preview/data-preview-section-container/data-preview-section-container.tsx
+++ b/src/components/data-preview/data-preview-section-container/data-preview-section-container.tsx
@@ -427,6 +427,8 @@ const DataPreviewSectionContainer: FunctionComponent<DataPreviewSectionProps> = 
                     allActiveFilters={allActiveFilters}
                     setAllActiveFilters={setAllActiveFilters}
                     disableDateRangeFilter={selectedTable?.apiFilter?.disableDateRangeFilter}
+                    datasetName={config.name}
+                    hasDownloadTimestamp={config.downloadTimestamp}
                   />
                 )}
               </div>

--- a/src/components/data-preview/data-preview-table/data-preview-table.tsx
+++ b/src/components/data-preview/data-preview-table/data-preview-table.tsx
@@ -93,6 +93,8 @@ const DataPreviewTable: FunctionComponent<DataPreviewTableProps> = ({
   setAllActiveFilters,
   userFilterSelection,
   disableDateRangeFilter,
+  hasDownloadTimestamp,
+  datesetName,
 }) => {
   const {
     dePaginated,
@@ -474,6 +476,9 @@ const DataPreviewTable: FunctionComponent<DataPreviewTableProps> = ({
                 setAllActiveFilters={setAllActiveFilters}
                 setTableSorting={setTableSorting}
                 disableDateRangeFilter={disableDateRangeFilter}
+                datasetName={datesetName}
+                dateRange={tableProps.dateRange}
+                hasDownloadTimestamp={hasDownloadTimestamp}
               />
             </ErrorBoundary>
           )}

--- a/src/components/data-table/data-table-helper.tsx
+++ b/src/components/data-table/data-table-helper.tsx
@@ -6,7 +6,6 @@ import TextFilter from './data-table-header/text-filter/text-filter';
 import DateRangeFilter from './data-table-header/date-range-filter/date-range-filter';
 import CustomLink from '../links/custom-link/custom-link';
 import { updateTableButton, downloadLinkContainer, downloadLinkIcon } from './data-table.module.scss';
-import { ENV_ID } from 'gatsby-env-variables';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCloudArrowDown } from '@fortawesome/free-solid-svg-icons';
 
@@ -335,4 +334,18 @@ export const getSortedColumnsData = (
     }));
     setTableColumnSortData(mapped);
   }
+};
+
+export const constructDateHeader = (datasetName, dateRange) => {
+  const timestampData = [];
+  timestampData.push(`${datasetName}.`);
+  const date = new Date(dateRange.to.toString());
+  const dateFormatted = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+  const lastDateOfMonth = `${dateFormatted}`;
+  timestampData.push(`As of ${lastDateOfMonth}`);
+  return timestampData;
 };

--- a/src/components/data-table/data-table-test-helper.js
+++ b/src/components/data-table/data-table-test-helper.js
@@ -173,6 +173,48 @@ export const mockTableData1Row = {
   daily_int_accrual_rate: '0.222222222',
   spread: '-0.1200',
 };
+export const mockTableDownloadWithTextQualifier = {
+  data: [
+    {
+      record_date: '2023-07-12',
+      string_val: 'just a normal string',
+      string_val_with_commas: 'comma, separated, list',
+    },
+  ],
+  meta: {
+    count: 1,
+    labels: {
+      record_date: 'Record Date',
+      string_val: 'String Value',
+      string_val_with_commas: 'String Value with Commas',
+    },
+    dataTypes: {
+      record_date: 'DATE',
+      string_val: 'String',
+      string_val_with_commas: 'String',
+    },
+    dataFormats: {
+      record_date: 'YYYY-MM-DD',
+    },
+    'total-count': 1,
+    'total-pages': 1,
+  },
+};
+
+export const mockColumnConfigDownloadWithTextQualifier = [
+  {
+    property: 'record_date',
+    name: 'Record Date',
+  },
+  {
+    property: 'string_val',
+    name: 'String Value',
+  },
+  {
+    property: 'string_val_with_commas',
+    name: 'String Value with Commas',
+  },
+];
 
 export const mockTableData = {
   data: [

--- a/src/components/data-table/data-table.spec.js
+++ b/src/components/data-table/data-table.spec.js
@@ -18,8 +18,12 @@ import {
   mockColumnConfig,
   mockDetailViewColumnConfig,
   mockDetailApiData,
+  mockTableDownloadWithTextQualifier,
+  mockColumnConfigDownloadWithTextQualifier,
 } from './data-table-test-helper';
 import userEvent from '@testing-library/user-event';
+import { smallTableDownloadDataCSV } from '../../recoil/smallTableDownloadData';
+import { RecoilObserver } from '../../utils/test-utils';
 
 describe('react-table', () => {
   const setTableColumnSortData = jest.fn();
@@ -587,6 +591,33 @@ describe('react-table', () => {
       </RecoilRoot>
     );
     expect(instance).toBeTruthy();
+  });
+
+  it('updates recoil state for csv download with text qualifiers', () => {
+    const setSmallTableDownloadDataCSV = jest.fn();
+    render(
+      <RecoilRoot>
+        <RecoilObserver node={smallTableDownloadDataCSV} onChange={setSmallTableDownloadDataCSV} />
+        <DataTable
+          rawData={mockTableDownloadWithTextQualifier}
+          pagingProps={{ itemsPerPage: 10 }}
+          setTableColumnSortData={setTableColumnSortData}
+          shouldPage
+          showPaginationControls
+          setFiltersActive={jest.fn()}
+          columnConfig={mockColumnConfigDownloadWithTextQualifier}
+          setTableSorting={jest.fn()}
+          dateRange={{
+            from: '2022-08-31',
+            to: '2024-08-31',
+          }}
+        />
+      </RecoilRoot>
+    );
+    expect(setSmallTableDownloadDataCSV).toHaveBeenCalledWith([
+      ['Record Date', 'String Value', 'String Value with Commas'],
+      ['2023-07-12', 'just a normal string', '"comma, separated, list"'],
+    ]);
   });
 
   it('formats FRN Daily Index number values correctly', () => {

--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -240,7 +240,11 @@ const DataTable: FunctionComponent<IDataTableProps> = ({
         setSmallTableJSONData(JSON.stringify({ data: downloadData }));
         setSmallTableXMLData(json2xml(JSON.stringify(xmlData), { compact: true }));
         downloadData = downloadData.map(entry => {
-          return Object.values(entry);
+          const dataWithTextQualifiers = [];
+          Object.values(entry).forEach(val => {
+            dataWithTextQualifiers.push(val.includes(',') ? `"${val}"` : val);
+          });
+          return dataWithTextQualifiers;
         });
         downloadData.unshift(downloadHeaders);
         if (hasDownloadTimestamp) {

--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -242,7 +242,7 @@ const DataTable: FunctionComponent<IDataTableProps> = ({
         downloadData = downloadData.map(entry => {
           const dataWithTextQualifiers = [];
           Object.values(entry).forEach(val => {
-            dataWithTextQualifiers.push(val.includes(',') ? `"${val}"` : val);
+            dataWithTextQualifiers.push(val?.includes(',') ? `"${val}"` : val);
           });
           return dataWithTextQualifiers;
         });

--- a/src/components/download-wrapper/download-item-button/download-item-button.jsx
+++ b/src/components/download-wrapper/download-item-button/download-item-button.jsx
@@ -85,7 +85,7 @@ const DownloadItemButton = ({
           {downloadTimestamp ? (
             <>
               <div
-                data-testid={'csv-timestamp-download-button'}
+                data-testid="csv-timestamp-download-button"
                 role="button"
                 onClick={() => captureTimestamp()}
                 className={`${downloadItemBtn} ${disabled ? linkDisabled : ''}`}
@@ -102,7 +102,7 @@ const DownloadItemButton = ({
                 onClick={() => clickFunction(true)}
                 ref={ref}
                 aria-hidden={true}
-                enclosingCharacter={''}
+                enclosingCharacter=""
                 tabIndex={-1}
               />
             </>
@@ -113,7 +113,7 @@ const DownloadItemButton = ({
               data={smallTableCSVData}
               filename={downloadName + '.csv'}
               onClick={() => clickFunction(true)}
-              enclosingCharacter={''}
+              enclosingCharacter=""
             >
               {children}
             </CSVLink>

--- a/src/models/IDataTableProps.ts
+++ b/src/models/IDataTableProps.ts
@@ -1,3 +1,5 @@
+import { SortingState } from '@tanstack/react-table';
+
 export interface IDataTableProps {
   // defaultSelectedColumns will be null unless the dataset has default columns specified in the dataset config
   rawData;
@@ -34,5 +36,7 @@ export interface IDataTableProps {
   allActiveFilters: string[];
   setAllActiveFilters: (value: string[]) => void;
   setTableSorting?: (value: SortingState) => void;
+  datasetName: string;
+  dateRange;
   disableDateRangeFilter: boolean;
 }

--- a/src/utils/test-utils.js
+++ b/src/utils/test-utils.js
@@ -1,0 +1,8 @@
+import { useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+
+export const RecoilObserver = ({ node, onChange }) => {
+  const value = useRecoilValue(node);
+  useEffect(() => onChange(value), [onChange, value]);
+  return null;
+};


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-10029

Test coverage: 90.15%

Note: I noticed code for the hasTimestamp download was missing from the now table so I moved that over