### PR TITLE
FDG-9114 G-Hook in the Data for the Glossary File

### DIFF
--- a/src/components/glossary/glossary-term/glossary-popover-definition.spec.js
+++ b/src/components/glossary/glossary-term/glossary-popover-definition.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import GlossaryPopoverDefinition from './glossary-popover-definition';
 import { GlossaryContext } from '../glossary-context/glossary-context';
 import userEvent from '@testing-library/user-event';

--- a/src/components/glossary/glossary-term/glossary-popover-definition.spec.js
+++ b/src/components/glossary/glossary-term/glossary-popover-definition.spec.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import GlossaryPopoverDefinition from './glossary-popover-definition';
 import { GlossaryContext } from '../glossary-context/glossary-context';
 import userEvent from '@testing-library/user-event';
+import { getFiscalYearByDate } from '../../../helpers/dates/date-helpers';
 
 describe('glossary term', () => {
   const testGlossary = [
@@ -35,6 +36,14 @@ describe('glossary term', () => {
       term: 'Debt Held by the Public',
       site_page: 'Test Page',
       definition: 'Test for term with custom style for not.',
+      url_display: '',
+      url_path: '',
+    },
+    {
+      id: 5,
+      term: 'Fiscal Year',
+      site_page: 'Test Page',
+      definition: 'For example, Fiscal Year 1111 (FY 1111) started October 1, 1110, and ended September 30, 1111.',
       url_display: '',
       url_path: '',
     },
@@ -117,6 +126,26 @@ describe('glossary term', () => {
 
     const styledText = getByText('not');
     expect(styledText).toHaveStyle({ textDecoration: 'underline' });
+  });
+
+  it('handles the fiscal year special case', () => {
+    const termText = 'Fiscal Year';
+    const testPage = 'Test Page';
+    const fy = getFiscalYearByDate();
+    const expected = `For example, Fiscal Year ${fy - 1} (FY ${fy - 1}) started October 1, ${fy - 2}, and ended September 30, ${fy - 1}.`;
+
+    const { getByRole, getByText } = render(
+      <GlossaryContext.Provider value={{ glossaryClickEvent: false, setGlossaryClickEvent: jest.fn(), glossary: testGlossary }}>
+        <GlossaryPopoverDefinition term={termText} page={testPage}>
+          {termText}
+        </GlossaryPopoverDefinition>
+      </GlossaryContext.Provider>
+    );
+    const glossaryTermButton = getByRole('button', { name: termText });
+    glossaryTermButton.click();
+
+    const definition = getByText('For example', { exact: false });
+    expect(definition.textContent).toEqual(expected);
   });
 
   it('correctly displays the definition for the term associated with the specified page', () => {

--- a/src/helpers/dates/date-helpers.js
+++ b/src/helpers/dates/date-helpers.js
@@ -22,3 +22,8 @@ export const isValidDateRange = (startDate, endDate, earliestDate, latestDate) =
 
   return true;
 };
+
+export const getFiscalYearByDate = (date = new Date()) => {
+  const september = 8;
+  return date.getMonth() > september ? date.getFullYear() + 1 : date.getFullYear();
+};

--- a/src/helpers/dates/date-helpers.spec.js
+++ b/src/helpers/dates/date-helpers.spec.js
@@ -1,4 +1,4 @@
-import { isValidDateRange } from './date-helpers';
+import { isValidDateRange, getFiscalYearByDate } from './date-helpers';
 
 describe('Date helper', () => {
   const earliest = '01/01/2000';
@@ -28,5 +28,14 @@ describe('Date helper', () => {
     endDate = '01/01/2025';
 
     expect(isValidDateRange(startDate, endDate, earliest, latest)).toBe(false);
+  });
+
+  it('returns the correct fiscal year', () => {
+    const endOfSept = new Date('09/30/2025');
+    const beginOfOct = new Date('10/01/2025');
+
+    expect(getFiscalYearByDate(endOfSept)).toBe(2025);
+    expect(getFiscalYearByDate(beginOfOct)).toBe(2026);
+    expect(`${getFiscalYearByDate()}`).toMatch(/^(\d{4})$/g);
   });
 });

--- a/src/helpers/glossary-helper/glossary-lookup.js
+++ b/src/helpers/glossary-helper/glossary-lookup.js
@@ -2,6 +2,7 @@ import { findGlossaryTerm } from './glossary-terms';
 import CustomLink from '../../components/links/custom-link/custom-link';
 import React from 'react';
 import reactStringReplace from 'react-string-replace';
+import { getFiscalYearByDate } from '../dates/date-helpers';
 
 const customFormatting = {
   'Debt Held by the Public': {
@@ -30,6 +31,20 @@ export const applyFormatting = entry => {
     definition = urlFormat(entry, definition);
   }
 
+  definition = handleFiscalYearCase(entry.term, definition);
+  return definition;
+};
+
+const handleFiscalYearCase = (entry, definition) => {
+  if (entry.term === 'Fiscal Year') {
+    const fiscalYear = getFiscalYearByDate();
+    const yearRgx = /(\d{4})/g;
+    let index = 0;
+    definition = reactStringReplace(definition, yearRgx, (match, i) => {
+      const yearOffset = index++ === 2 ? 2 : 1;
+      return fiscalYear - yearOffset;
+    });
+  }
   return definition;
 };
 
@@ -51,6 +66,9 @@ export const glossaryLookup = (value, glossary, page) => {
     }
     if (!customFormat && entry.url_display && entry.url_path) {
       definitionFormatted = urlFormat(entry, definitionFormatted);
+    }
+    if (!customFormat) {
+      definitionFormatted = handleFiscalYearCase(entry, definitionFormatted);
     }
   }
 

--- a/src/helpers/glossary-helper/glossary-lookup.js
+++ b/src/helpers/glossary-helper/glossary-lookup.js
@@ -35,19 +35,6 @@ export const applyFormatting = entry => {
   return definition;
 };
 
-const handleFiscalYearCase = (entry, definition) => {
-  if (entry.term === 'Fiscal Year') {
-    const fiscalYear = getFiscalYearByDate();
-    const yearRgx = /(\d{4})/g;
-    let index = 0;
-    definition = reactStringReplace(definition, yearRgx, (match, i) => {
-      const yearOffset = index++ === 2 ? 2 : 1;
-      return fiscalYear - yearOffset;
-    });
-  }
-  return definition;
-};
-
 export const glossaryLookup = (value, glossary, page) => {
   const entry = findGlossaryTerm(value, glossary)?.filter(e => e.site_page.includes(page.split(' ')[0]))[0];
   let glossaryTerm = '';
@@ -67,9 +54,7 @@ export const glossaryLookup = (value, glossary, page) => {
     if (!customFormat && entry.url_display && entry.url_path) {
       definitionFormatted = urlFormat(entry, definitionFormatted);
     }
-    if (!customFormat) {
-      definitionFormatted = handleFiscalYearCase(entry, definitionFormatted);
-    }
+    definitionFormatted = handleFiscalYearCase(entry, definitionFormatted);
   }
 
   return {
@@ -83,4 +68,17 @@ export const urlFormat = (entry, definitionFormatted) => {
   return reactStringReplace(definitionFormatted, entry.url_display, match => {
     return <CustomLink url={entry.url_path}>{match}</CustomLink>;
   });
+};
+
+const handleFiscalYearCase = (entry, definition) => {
+  if (entry.term === 'Fiscal Year') {
+    const fiscalYear = getFiscalYearByDate();
+    const yearRgx = /(\d{4})/g;
+    let index = 0;
+    definition = reactStringReplace(definition, yearRgx, (match, i) => {
+      const yearOffset = index++ === 2 ? 2 : 1;
+      return fiscalYear - yearOffset;
+    });
+  }
+  return definition;
 };


### PR DESCRIPTION
[FDG-9114 Jira](https://federal-spending-transparency.atlassian.net/browse/FDG-9114)

Description: The Fiscal Year definition in the glossary (**Resources -> Glossary -> Fiscal Year**) should now use the last-completed fiscal year, regardless of the year in the original definition.

Note: This was done using Date() logic rather than the API originally requested in the ticket. (Approved by ticket writer and the data team.)

To Validate:

The Fiscal Year definition in the glossary should return:
> "...For example, Fiscal Year 2024 (FY 2024) started October 1, 2023, and ended September 30, 2024..."

On October 1, 2025, that should update to:
> "...For example, Fiscal Year 2025 (FY 2025) started October 1, 2024, and ended September 30, 2025..."

