### PR TITLE
FDG-10330 Datasets search page Sort By is Alphabetical (A to Z) when entered the page, but as soon as we search for a dataset the sort is changing to Recently Updated.

### DIFF
--- a/src/components/datasets/search-results/search-results-helper.js
+++ b/src/components/datasets/search-results/search-results-helper.js
@@ -7,13 +7,6 @@ export const SortOptions = [
     },
   },
   {
-    id: 'lastUpdated',
-    label: 'Recently Updated',
-    sortFn: (a, b) => {
-      return Date.parse(b.techSpecs.lastUpdated) - Date.parse(a.techSpecs.lastUpdated);
-    },
-  },
-  {
     id: 'alpha',
     label: 'Alphabetical (A to Z)',
     sortFn: (a, b) => {
@@ -25,6 +18,13 @@ export const SortOptions = [
     label: 'Alphabetical (Z to A)',
     sortFn: (a, b) => {
       return b.name.localeCompare(a.name);
+    },
+  },
+  {
+    id: 'lastUpdated',
+    label: 'Recently Updated',
+    sortFn: (a, b) => {
+      return Date.parse(b.techSpecs.lastUpdated) - Date.parse(a.techSpecs.lastUpdated);
     },
   },
 ];

--- a/src/components/datasets/search-results/search-results-helper.spec.js
+++ b/src/components/datasets/search-results/search-results-helper.spec.js
@@ -1,4 +1,4 @@
-import { SortOptions, SortOptionsIndexed, FilteredSortOptions, PerformSort } from './search-results-helper';
+import { FilteredSortOptions, PerformSort, SortOptions, SortOptionsIndexed } from './search-results-helper';
 
 const mockDatasets = [
   {
@@ -41,12 +41,12 @@ describe('search results helper', () => {
   });
 
   it('sorts by title from A to Z', () => {
-    PerformSort(SortOptions[2], mockDatasets);
+    PerformSort(SortOptions[1], mockDatasets);
     expect(mockDatasets[0].name).toBe('Dataset A');
   });
 
   it('sorts by title from Z to A', () => {
-    PerformSort(SortOptions[3], mockDatasets);
+    PerformSort(SortOptions[2], mockDatasets);
     expect(mockDatasets[0].name).toBe('Dataset C');
   });
 

--- a/src/components/datasets/search-results/search-results.jsx
+++ b/src/components/datasets/search-results/search-results.jsx
@@ -1,12 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import SearchResultCount from '../search-result-count/search-result-count';
 import SearchResultCards from './search-result-cards/search-result-cards';
 import SortDatasets from './sort-datasets/sort-datasets';
-import { SortOptions, FilteredSortOptions } from './search-results-helper';
+import { FilteredSortOptions, SortOptions } from './search-results-helper';
 import NotShownMessage from '../../dataset-data/table-section-container/not-shown-message/not-shown-message';
 import Analytics from '../../../utils/analytics/analytics';
 
-import { noMargin, datasetHeader, datasetsSubtitle, sortSelectionContainer } from './search-results.module.scss';
+import { datasetHeader, datasetsSubtitle, noMargin, sortSelectionContainer } from './search-results.module.scss';
 
 export const sortDatasetsAnalyticsObject = {
   category: 'Dataset Search Page',
@@ -41,7 +41,7 @@ const SearchResults = ({ searchIsActive, filteredDatasets, allDatasets }) => {
   const allDatasetsLength = allDatasets.length;
 
   const sortOptions = searchIsActive ? SortOptions : FilteredSortOptions;
-  const [activeSort, setActiveSort] = useState(sortOptions[1]);
+  const [activeSort, setActiveSort] = useState(sortOptions[0]);
   const [totalApiLength, setTotalApiLength] = useState(0);
   const [filteredApiLength, setFilteredApiLength] = useState(0);
 
@@ -75,7 +75,7 @@ const SearchResults = ({ searchIsActive, filteredDatasets, allDatasets }) => {
 
   const noResultsMessage = <NotShownMessage heading={noResultsText.heading} bodyText={noResultBody} />;
 
-  useEffect(() => setActiveSort(sortOptions[1]), [sortOptions, searchIsActive]);
+  useEffect(() => setActiveSort(sortOptions[0]), [sortOptions, searchIsActive]);
 
   useEffect(() => {
     const filteredCount = getApiCount(filteredDatasets);

--- a/src/components/datasets/search-results/search-results.spec.js
+++ b/src/components/datasets/search-results/search-results.spec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { render, fireEvent, within } from '@testing-library/react';
-import SearchResults, { getApiCount, resultsHeaderText, noResultsText } from './search-results';
+import { fireEvent, render, within } from '@testing-library/react';
+import SearchResults, { getApiCount, noResultsText, resultsHeaderText } from './search-results';
 import { getSearchResultText } from '../search-result-count/search-result-count';
-import { SortOptions, FilteredSortOptions } from './search-results-helper';
+import { FilteredSortOptions, SortOptions } from './search-results-helper';
 import { sortSelectionContainer } from './search-results.module.scss';
 
 const mockAllDatasets = [
@@ -59,7 +59,7 @@ describe('Search Results', () => {
       <SearchResults allDatasets={mockAllDatasets} filteredDatasets={mockFilteredDatasets} totalCount={mockTotal} searchIsActive />
     );
 
-    expect(getByText(SortOptions[1].label)).toBeInTheDocument();
+    expect(getByText(SortOptions[0].label)).toBeInTheDocument();
   });
 
   it('passes the filtered list of options to the sort control when search is inactive', () => {
@@ -67,7 +67,7 @@ describe('Search Results', () => {
       <SearchResults allDatasets={mockAllDatasets} filteredDatasets={mockFilteredDatasets} totalCount={mockTotal} searchIsActive={false} />
     );
 
-    expect(getByText(FilteredSortOptions[1].label)).toBeInTheDocument();
+    expect(getByText(FilteredSortOptions[0].label)).toBeInTheDocument();
   });
 
   it('changes the sort back to alpha when search is cleared', () => {
@@ -75,10 +75,10 @@ describe('Search Results', () => {
       <SearchResults allDatasets={mockAllDatasets} filteredDatasets={mockFilteredDatasets} totalCount={mockTotal} searchIsActive />
     );
 
-    expect(getByText(SortOptions[1].label)).toBeInTheDocument();
+    expect(getByText(SortOptions[0].label)).toBeInTheDocument();
 
     rerender(<SearchResults allDatasets={mockAllDatasets} filteredDatasets={mockFilteredDatasets} totalCount={mockTotal} searchIsActive={false} />);
-    expect(getByText(FilteredSortOptions[1].label)).toBeInTheDocument();
+    expect(getByText(FilteredSortOptions[0].label)).toBeInTheDocument();
   });
 
   it('displays an info box when no search results are returned', () => {
@@ -116,7 +116,7 @@ describe('Search Results', () => {
 
     expect(datalayerSpy).toHaveBeenCalledWith({
       event: 'Sort Click',
-      eventLabel: 'Alphabetical (Z to A)',
+      eventLabel: 'Recently Updated',
     });
   });
 });


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/FDG-10330