### PR TITLE
FDG-10565 When user typed ‘May 23, 2029’ into the input box and press Num Lock enter on the keyboard it is not displaying the error msg

### DIFF
--- a/src/components/date-picker/date-text-input/date-text-input.tsx
+++ b/src/components/date-picker/date-text-input/date-text-input.tsx
@@ -143,7 +143,7 @@ const DateTextInput: FunctionComponent<iDateTextInput> = ({
 
   const handleOnKeyDown = e => {
     const input = e.target.value;
-    if (e.code === 'Enter') {
+    if (e.key === 'Enter') {
       isValid(input);
     }
   };


### PR DESCRIPTION
… Num Lock enter on the keyboard it is not displaying the error msg

**JIRA Ticket:**

[FDG-10565](https://federal-spending-transparency.atlassian.net/browse/FDG-10565)

***The following are ALL required for the PR to be merged:***

- [x] Provided testing instructions in JIRA ticket `if applicable`
- [x] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [x] Verified mobile/tablet/desktop/monitor responsiveness
- [x] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [x] Verify all files are covered by at least 90% test coverage `if applicable`
- [x] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
