### PR TITLE
FDG-10767 UTF DDP page when selecting 100 Rows per page is either missing a scroll bar or it is displaying only one row of data even though it has 119568 rows

### DIFF
--- a/src/components/data-table/data-table-footer/data-table-footer.tsx
+++ b/src/components/data-table/data-table-footer/data-table-footer.tsx
@@ -58,7 +58,10 @@ const DataTableFooter: FunctionComponent<IDataTableFooter> = ({
 
   // For serverside paginated data (unfiltered datasets > 20000 rows), use paging props
   const tablePagingProps = manualPagination
-    ? pagingProps
+    ? {
+        ...pagingProps,
+        handlePerPageChange: handlePerPageChange,
+      }
     : {
         itemsPerPage: pagingProps?.itemsPerPage,
         handlePerPageChange: x => {

--- a/src/components/dataset-data/table-section-container/table-section-container.jsx
+++ b/src/components/dataset-data/table-section-container/table-section-container.jsx
@@ -407,7 +407,9 @@ const TableSectionContainer = ({
                 userFilterUnmatchedForDateRange={userFilterUnmatchedForDateRange}
                 apiFilterDefault={apiFilterDefault && !selectedTable?.apiFilter?.displayDefaultData}
                 onToggleLegend={legendToggler}
-                emptyData={!isLoading && !serverSidePagination && (!apiData || !apiData.data || !apiData.data.length) && !apiError}
+                emptyData={
+                  !isLoading && !serverSidePagination && !userFilterSelection && (!apiData || !apiData.data || !apiData.data.length) && !apiError
+                }
                 unchartable={noChartMessage !== undefined}
                 currentTab={selectedTab}
                 datasetName={config?.name}

--- a/src/components/dtg-table/dtg-table.jsx
+++ b/src/components/dtg-table/dtg-table.jsx
@@ -358,7 +358,6 @@ export default function DtgTable({
         // large dataset tables <= 20000 rows
         setReactTableData(dePaginated);
         setManualPagination(false);
-        setMaxRows(dePaginated.data.length);
         setIsLoading(false);
       } else if (rawData !== null && rawData.hasOwnProperty('data')) {
         if (detailViewState && detailViewState?.secondary !== null && config?.detailView) {
@@ -375,6 +374,7 @@ export default function DtgTable({
       // user filter tables <= 20000 rows
       setReactTableData(dePaginated);
       setManualPagination(false);
+      setMaxRows(dePaginated.data.length);
       setIsLoading(false);
     }
   }, [rawData, dePaginated]);

--- a/src/components/dtg-table/dtg-table.jsx
+++ b/src/components/dtg-table/dtg-table.jsx
@@ -358,6 +358,7 @@ export default function DtgTable({
         // large dataset tables <= 20000 rows
         setReactTableData(dePaginated);
         setManualPagination(false);
+        setMaxRows(dePaginated.data.length);
         setIsLoading(false);
       } else if (rawData !== null && rawData.hasOwnProperty('data')) {
         if (detailViewState && detailViewState?.secondary !== null && config?.detailView) {

--- a/src/components/dtg-table/dtg-table.jsx
+++ b/src/components/dtg-table/dtg-table.jsx
@@ -295,7 +295,7 @@ export default function DtgTable({
       setCurrentPage(1);
       updateTable(true);
     }
-  }, [tableSorting, dateRange, selectedTable]);
+  }, [tableSorting, dateRange, selectedTable, tableMeta]);
 
   useMemo(() => {
     if (selectedTable?.rowCount > REACT_TABLE_MAX_NON_PAGINATED_SIZE) {


### PR DESCRIPTION
**JIRA Ticket:**

[FDG-10767](https://federal-spending-transparency.atlassian.net/browse/FDG-10767)

***The following are ALL required for the PR to be merged:***

- [ ] Provided testing instructions in JIRA ticket `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [ ] Verify all files are covered by at least 90% test coverage `if applicable`
- [ ] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
