### PR TITLE
FDG-10750 Callout on the Spending Explainer page is missing a period at the end of the sentence

### DIFF
--- a/src/layouts/explainer/sections/federal-spending/spending-categories/spending-categories.jsx
+++ b/src/layouts/explainer/sections/federal-spending/spending-categories/spending-categories.jsx
@@ -51,7 +51,7 @@ export const SpendingCategories = () => {
         >
           Each year, the Social Security and Medicare Boards of Trustees publish their {ssaAnnualReport}. The Boards’ projections indicate that
           spending will continue to increase. As the average age of Americans increases, more funding is needed to support entitlement programs like
-          Social Security, Medicare, and retirement and disability services for both military and civil servants{' '}
+          Social Security, Medicare, and retirement and disability services for both military and civil servants.{' '}
         </Accordion>
       </div>
     </div>


### PR DESCRIPTION
**JIRA Ticket:**
[FDG-10750](https://federal-spending-transparency.atlassian.net/browse/FDG-10750)

***The following are ALL required for the PR to be merged:***

- [ ] Provided testing instructions in JIRA ticket `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [ ] Verify all files are covered by at least 90% test coverage `if applicable`
- [ ] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
