### PR TITLE
FDG-11162 On Spending page "U.S. Government Spending, FYTD 2026" is displaying dollar amount, but it should be a "-ve" amount.

### DIFF
--- a/src/layouts/explainer/sections/federal-spending/how-much-does-the-govt-spend/how-much-does-the-govt-spend.jsx
+++ b/src/layouts/explainer/sections/federal-spending/how-much-does-the-govt-spend/how-much-does-the-govt-spend.jsx
@@ -184,6 +184,7 @@ const HowMuchDoesTheGovtSpend = () => {
     ?.reduce((item, nextItem) => {
       return item + nextItem;
     }, 0);
+  const formatDollars = number => `${number < 0 ? '-' : ''}$${getShortForm(Math.abs(number))}`;
   const otherPercentage = Math.round((otherTotal / total) * 100);
 
   const animationEndHandler = useCallback(() => {
@@ -359,7 +360,7 @@ const HowMuchDoesTheGovtSpend = () => {
             <div className={animationComplete ? active : undefined}>
               <div className={chartsContainer} key={otherPercentage}>
                 <GrowDivBar percent={otherPercentage} animateTime={0.6} animate={animateBars} isMobile={isMobile} />
-                <div className={percentOrDollarContainer}>{percentDollarToggleChecked ? `$${getShortForm(otherTotal)}` : `${otherPercentage} %`}</div>
+                <div className={percentOrDollarContainer}>{percentDollarToggleChecked ? formatDollars(otherTotal) : `${otherPercentage} %`}</div>
                 <div className={descContainer}>Other</div>
               </div>
             </div>

--- a/src/utils/rounding-utils.ts
+++ b/src/utils/rounding-utils.ts
@@ -1,8 +1,5 @@
 export const getShortForm = (value: string, abbreviate: boolean = true, round: boolean = true, fractionDigits: number = 0): string => {
-  const num = Number(value);
-  const isNegative = num < 0;
-  const abs = Math.abs(num);
-  const trimmed = abs.toFixed();
+  const trimmed = Math.abs(Number(value)).toFixed();
   const inTrillions = trimmed.length > 12;
   const inBillions = trimmed.length > 9;
   let divisor;
@@ -26,9 +23,9 @@ export const getShortForm = (value: string, abbreviate: boolean = true, round: b
   }
   const digits = round ? (inTrillions ? 2 : 0) : fractionDigits;
 
-  const numberShortened = (abs / divisor).toFixed(digits);
+  const numberShortened = Math.abs(parseFloat(value) / divisor).toFixed(digits);
 
   const removedTrailingZero = numberShortened.replace(/\.0+$/, '');
-  const sign = isNegative ? '-' : '';
-  return `${sign}${removedTrailingZero}${appendix}`;
+
+  return removedTrailingZero + appendix;
 };

--- a/src/utils/rounding-utils.ts
+++ b/src/utils/rounding-utils.ts
@@ -1,5 +1,8 @@
 export const getShortForm = (value: string, abbreviate: boolean = true, round: boolean = true, fractionDigits: number = 0): string => {
-  const trimmed = Math.abs(Number(value)).toFixed();
+  const num = Number(value);
+  const isNegative = num < 0;
+  const abs = Math.abs(num);
+  const trimmed = abs.toFixed();
   const inTrillions = trimmed.length > 12;
   const inBillions = trimmed.length > 9;
   let divisor;
@@ -23,9 +26,9 @@ export const getShortForm = (value: string, abbreviate: boolean = true, round: b
   }
   const digits = round ? (inTrillions ? 2 : 0) : fractionDigits;
 
-  const numberShortened = Math.abs(parseFloat(value) / divisor).toFixed(digits);
+  const numberShortened = (abs / divisor).toFixed(digits);
 
   const removedTrailingZero = numberShortened.replace(/\.0+$/, '');
-
-  return removedTrailingZero + appendix;
+  const sign = isNegative ? '-' : '';
+  return `${sign}${removedTrailingZero}${appendix}`;
 };


### PR DESCRIPTION
**JIRA Ticket:**

[FDG-11162](https://federal-spending-transparency.atlassian.net/browse/FDG-11162)

***The following are ALL required for the PR to be merged:***

- [ ] Provided testing instructions in JIRA ticket `if applicable`
- [ ] Provided mocks or additional information in JIRA ticket `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [ ] Verify all files are covered by at least 90% test coverage `if applicable`
- [ ] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
