### PR TITLE
FDG-11222 National debt page is not displaying the data it is displaying glitch on iPhone and Mac

### DIFF
--- a/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-trends-over-time/debt-trends-over-time-chart.jsx
+++ b/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-trends-over-time/debt-trends-over-time-chart.jsx
@@ -2,7 +2,7 @@ import { pxToNumber } from '../../../../../../helpers/styles-helper/styles-helpe
 import { breakpointLg, debtExplainerPrimary, fontSize_10 } from '../../../../../../variables.module.scss';
 import React, { useEffect, useState } from 'react';
 import Analytics from '../../../../../../utils/analytics/analytics';
-import { container, header, headerContainer, lineChartContainer, subHeader, loadingIcon } from './debt-trends-over-time-chart.module.scss';
+import { container, header, headerContainer, lineChartContainer, loadingIcon, subHeader } from './debt-trends-over-time-chart.module.scss';
 import { visWithCallout } from '../../../../explainer.module.scss';
 import { Line } from '@nivo/line';
 import VisualizationCallout from '../../../../../../components/visualization-callout/visualization-callout';
@@ -174,7 +174,7 @@ export const DebtTrendsOverTimeChart = ({ sectionId, beaGDPData, width }) => {
               subTitle="Debt to Gross Domestic Product (GDP)"
               header={headerContent()}
               footer={footerContent}
-              date={getDateWithoutTimeZoneAdjust(`${lastDebtValue.x}-09-30`)}
+              date={lastDebtValue?.x ? getDateWithoutTimeZoneAdjust(`${lastDebtValue.x}-09-30`) : new Date()}
               altText={`Line graph displaying the federal debt to GDP trend over time from ${debtTrendsData[0]?.data[0].x ?? '-'} to ${
                 lastDebtValue.x
               }.`}


### PR DESCRIPTION
**JIRA Ticket:**

[FDG-11222](https://federal-spending-transparency.atlassian.net/browse/FDG-11222)

***The following are ALL required for the PR to be merged:***

- [ ] Provided testing instructions in JIRA ticket `if applicable`
- [ ] Provided mocks or additional information in JIRA ticket `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [ ] Verify all files are covered by at least 90% test coverage `if applicable`
- [ ] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
