### PR TITLE
FDG 11204 At around 991px the images on federal Spending get large enough for the text to become a bit pixelated

### DIFF
--- a/src/layouts/explainer/sections/federal-spending/spending-difference/spending-difference.module.scss
+++ b/src/layouts/explainer/sections/federal-spending/spending-difference/spending-difference.module.scss
@@ -30,7 +30,7 @@
   .mandatorySpendingImgStyle {
     padding-right: 0;
   }
-  @media screen and (min-width: $breakpoint-sm) and (max-width: $breakpoint-lg) {
+  @media screen and (max-width: $breakpoint-lg) {
     .mandatorySpendingContainer {
       max-width: 375px;
       justify-self: center;

--- a/src/layouts/explainer/sections/federal-spending/spending-difference/spending-difference.module.scss
+++ b/src/layouts/explainer/sections/federal-spending/spending-difference/spending-difference.module.scss
@@ -30,4 +30,11 @@
   .mandatorySpendingImgStyle {
     padding-right: 0;
   }
+  @media screen and (min-width: $breakpoint-sm) and (max-width: $breakpoint-lg) {
+    .mandatorySpendingContainer {
+      width: 50%;
+      justify-self: center;
+      display: flex;
+    }
+  }
 }

--- a/src/layouts/explainer/sections/federal-spending/spending-difference/spending-difference.module.scss
+++ b/src/layouts/explainer/sections/federal-spending/spending-difference/spending-difference.module.scss
@@ -32,7 +32,7 @@
   }
   @media screen and (min-width: $breakpoint-sm) and (max-width: $breakpoint-lg) {
     .mandatorySpendingContainer {
-      width: 375px;
+      max-width: 375px;
       justify-self: center;
       display: flex;
     }

--- a/src/layouts/explainer/sections/federal-spending/spending-difference/spending-difference.module.scss
+++ b/src/layouts/explainer/sections/federal-spending/spending-difference/spending-difference.module.scss
@@ -32,7 +32,7 @@
   }
   @media screen and (min-width: $breakpoint-sm) and (max-width: $breakpoint-lg) {
     .mandatorySpendingContainer {
-      width: 50%;
+      width: 600px;
       justify-self: center;
       display: flex;
     }

--- a/src/layouts/explainer/sections/federal-spending/spending-difference/spending-difference.module.scss
+++ b/src/layouts/explainer/sections/federal-spending/spending-difference/spending-difference.module.scss
@@ -32,7 +32,7 @@
   }
   @media screen and (min-width: $breakpoint-sm) and (max-width: $breakpoint-lg) {
     .mandatorySpendingContainer {
-      width: 600px;
+      width: 375px;
       justify-self: center;
       display: flex;
     }


### PR DESCRIPTION
**JIRA Ticket:**

[FDG-11204](https://federal-spending-transparency.atlassian.net/browse/FDG-11204)

***The following are ALL required for the PR to be merged:***

- [ ] Provided testing instructions in JIRA ticket `if applicable`
- [ ] Provided mocks or additional information in JIRA ticket `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [ ] Verify all files are covered by at least 90% test coverage `if applicable`
- [ ] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
