### PR TITLE
FDG-11190 On DDP the search bars for Data Dictionary fields cannot be used for Android keyboard closed instantly when selecting one

### DIFF
--- a/src/components/dataset-properties-tabs/dataset-properties-tabs.jsx
+++ b/src/components/dataset-properties-tabs/dataset-properties-tabs.jsx
@@ -77,7 +77,7 @@ const DatasetPropertiesTabs = ({ config, test }) => {
             value={value}
             onChange={handleChange}
             variant={test ? 'standard' : 'scrollable'}
-            scrollButtons={SCROLL_TYPE.AUTO}
+            // scrollButtons={SCROLL_TYPE.AUTO}
             aria-label="Dataset properties tabs"
             indicatorColor="primary"
           >

--- a/src/components/dataset-properties-tabs/dataset-properties-tabs.jsx
+++ b/src/components/dataset-properties-tabs/dataset-properties-tabs.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { a11yProps } from '../datasets/filters/dateFilterTabs/dateFilterTabs';
 import { ThemeProvider } from '@mui/material/styles';
 import { dpTheme } from '../../theme';
@@ -10,11 +10,8 @@ import DataDictionary from '../data-dictionary/data-dictionary';
 import NotesAndLimitations from './notes-and-limitations/notes-and-limitations';
 import MetadataTab from '../metadata-tab/metadata-tab';
 import DataTablesTab from '../datatables-tab/datatables-tab';
-import { withWindowSize } from 'react-fns';
-import { breakpointSm } from '../../variables.module.scss';
-import { pxToNumber } from '../../helpers/styles-helper/styles-helper';
 
-const DatasetPropertiesTabs = ({ config, test, width }) => {
+const DatasetPropertiesTabs = ({ config, test }) => {
   const dictionaryPerPage = 5;
   const hideRawDataTable = config?.hideRawDataTable;
   const TabPanel = ({ children, value, index, ...other }) => (
@@ -36,7 +33,7 @@ const DatasetPropertiesTabs = ({ config, test, width }) => {
   };
 
   const [value, setValue] = useState(0);
-  const [scrollButton, setScrollButton] = useState(SCROLL_TYPE.ON);
+  // const [scrollButton, setScrollButton] = useState(SCROLL_TYPE.ON);
   const handleChange = (_, newValue) => {
     setValue(newValue);
   };
@@ -67,9 +64,10 @@ const DatasetPropertiesTabs = ({ config, test, width }) => {
 
   const tabs = !hideRawDataTable ? [...rawDataTableTabs, ...datasetTabs] : [...datasetTabs];
 
-  useEffect(() => {
-    setScrollButton(width <= pxToNumber(breakpointSm) ? SCROLL_TYPE.ON : SCROLL_TYPE.AUTO);
-  }, [width]);
+  // useEffect(() => {
+  //   console.log(width, window.innerWidth);
+  //   setScrollButton(width <= pxToNumber(breakpointSm) ? SCROLL_TYPE.ON : SCROLL_TYPE.AUTO);
+  // }, [width]);
 
   return (
     <div data-testid="tabsContainer">
@@ -79,7 +77,7 @@ const DatasetPropertiesTabs = ({ config, test, width }) => {
             value={value}
             onChange={handleChange}
             variant={test ? 'standard' : 'scrollable'}
-            scrollButtons={scrollButton}
+            scrollButtons={SCROLL_TYPE.AUTO}
             aria-label="Dataset properties tabs"
             indicatorColor="primary"
           >
@@ -97,4 +95,4 @@ const DatasetPropertiesTabs = ({ config, test, width }) => {
     </div>
   );
 };
-export default withWindowSize(DatasetPropertiesTabs);
+export default DatasetPropertiesTabs;

--- a/src/components/dataset-properties-tabs/dataset-properties-tabs.jsx
+++ b/src/components/dataset-properties-tabs/dataset-properties-tabs.jsx
@@ -27,13 +27,7 @@ const DatasetPropertiesTabs = ({ config, test }) => {
     </Typography>
   );
 
-  const SCROLL_TYPE = {
-    AUTO: 'auto',
-    ON: 'on',
-  };
-
   const [value, setValue] = useState(0);
-  // const [scrollButton, setScrollButton] = useState(SCROLL_TYPE.ON);
   const handleChange = (_, newValue) => {
     setValue(newValue);
   };
@@ -64,11 +58,6 @@ const DatasetPropertiesTabs = ({ config, test }) => {
 
   const tabs = !hideRawDataTable ? [...rawDataTableTabs, ...datasetTabs] : [...datasetTabs];
 
-  // useEffect(() => {
-  //   console.log(width, window.innerWidth);
-  //   setScrollButton(width <= pxToNumber(breakpointSm) ? SCROLL_TYPE.ON : SCROLL_TYPE.AUTO);
-  // }, [width]);
-
   return (
     <div data-testid="tabsContainer">
       <ThemeProvider theme={dpTheme}>
@@ -77,7 +66,6 @@ const DatasetPropertiesTabs = ({ config, test }) => {
             value={value}
             onChange={handleChange}
             variant={test ? 'standard' : 'scrollable'}
-            // scrollButtons={SCROLL_TYPE.AUTO}
             aria-label="Dataset properties tabs"
             indicatorColor="primary"
           >


### PR DESCRIPTION
**FDG-11190:**

[FDG-11190](https://federal-spending-transparency.atlassian.net/browse/FDG-11190)

***The following are ALL required for the PR to be merged:***

- [ ] Provided testing instructions in JIRA ticket `if applicable`
- [ ] Provided mocks or additional information in JIRA ticket `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [ ] Verify all files are covered by at least 93% test coverage `if applicable`
- [ ] Verify that dashes are used for any visible defaults of evergreen values `if applicable`
- [ ] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
