### PR TITLE
FDG-11192 In mobile view, the Interest Rate and Total Debt chart's x-axis labels are overlapping each other.

### DIFF
--- a/src/layouts/explainer/multichart/multichart.spec.js
+++ b/src/layouts/explainer/multichart/multichart.spec.js
@@ -196,4 +196,11 @@ describe('Multichart', () => {
     jest.advanceTimersByTime(6500);
     await waitFor(() => expect(multichart).toHaveStyle('pointer-events: auto'));
   });
+
+  it('calculates correct xAxisTickValues in mobile view', () => {
+    const mockData = mockTotalDebtData;
+    const isMobile = true;
+    const mobileAxisValues = mockData.map(d => new Date(d.record_date)).filter((_, i) => (isMobile ? i % 3 === 0 : true));
+    expect(mobileAxisValues.length).toBe(4);
+  });
 });

--- a/src/layouts/explainer/multichart/multichart.tsx
+++ b/src/layouts/explainer/multichart/multichart.tsx
@@ -3,6 +3,7 @@ import { MultichartRenderer } from '../../../components/charts/chart-primary/mul
 import { useInView } from 'react-intersection-observer';
 import { pxToNumber } from '../../../helpers/styles-helper/styles-helper';
 import { breakpointLg } from '../../../variables.module.scss';
+import { useWindowSize } from 'usehooks-ts';
 
 type ChartOptions = {
   forceHeight: number;
@@ -55,14 +56,13 @@ export type MultichartProperties = {
   chartConfigs: ChartConfig[];
   chartId: string;
   hoverEffectHandler: (recordDate: string | null) => void;
-  width: number;
 };
 
-const Multichart: FunctionComponent<MultichartProperties> = ({ chartConfigs, chartId, hoverEffectHandler, width }: MultichartProperties) => {
+const Multichart: FunctionComponent<MultichartProperties> = ({ chartConfigs, chartId, hoverEffectHandler }: MultichartProperties) => {
   const [chartRenderer, setChartRenderer] = useState(null);
   const [animateChart, setAnimateChart] = useState(false);
   const [hoverDisabled, setHoverDisabled] = useState(true);
-
+  const { width } = useWindowSize();
   const itemRef = useRef();
   // you can access the elements with itemsRef.current[n]
 
@@ -117,6 +117,7 @@ const Multichart: FunctionComponent<MultichartProperties> = ({ chartConfigs, cha
     }
   }, [inView]);
 
+  // adjusts amount of x-axis labels & re-generates the chart
   useEffect(() => {
     if (chartRenderer && chartRenderer.rendered) {
       const isMobile = width < pxToNumber(breakpointLg);
@@ -127,7 +128,7 @@ const Multichart: FunctionComponent<MultichartProperties> = ({ chartConfigs, cha
       });
       chartRenderer.generateChart();
     }
-  }, [width]);
+  }, [width, chartRenderer]);
 
   return (
     <>

--- a/src/layouts/explainer/multichart/multichart.tsx
+++ b/src/layouts/explainer/multichart/multichart.tsx
@@ -90,12 +90,6 @@ const Multichart: FunctionComponent<MultichartProperties> = ({ chartConfigs, cha
     }
   }, [window.innerWidth]);
 
-  useEffect(() => {
-    if (chartRenderer) {
-      chartRenderer.addAccessibilityLayer(hoverEffectHandler);
-    }
-  }, [chartRenderer]);
-
   const { ref: animationRef, inView } = useInView({
     threshold: 0,
     rootMargin: '-50% 0% -50% 0%',
@@ -127,6 +121,9 @@ const Multichart: FunctionComponent<MultichartProperties> = ({ chartConfigs, cha
         }
       });
       chartRenderer.generateChart();
+    }
+    if (chartRenderer) {
+      chartRenderer.addAccessibilityLayer(hoverEffectHandler);
     }
   }, [width, chartRenderer]);
 

--- a/src/layouts/explainer/multichart/multichart.tsx
+++ b/src/layouts/explainer/multichart/multichart.tsx
@@ -1,6 +1,8 @@
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { MultichartRenderer } from '../../../components/charts/chart-primary/multichart-renderer';
 import { useInView } from 'react-intersection-observer';
+import { pxToNumber } from '../../../helpers/styles-helper/styles-helper';
+import { breakpointLg } from '../../../variables.module.scss';
 
 type ChartOptions = {
   forceHeight: number;
@@ -53,9 +55,10 @@ export type MultichartProperties = {
   chartConfigs: ChartConfig[];
   chartId: string;
   hoverEffectHandler: (recordDate: string | null) => void;
+  width: number;
 };
 
-const Multichart: FunctionComponent<MultichartProperties> = ({ chartConfigs, chartId, hoverEffectHandler }: MultichartProperties) => {
+const Multichart: FunctionComponent<MultichartProperties> = ({ chartConfigs, chartId, hoverEffectHandler, width }: MultichartProperties) => {
   const [chartRenderer, setChartRenderer] = useState(null);
   const [animateChart, setAnimateChart] = useState(false);
   const [hoverDisabled, setHoverDisabled] = useState(true);
@@ -113,6 +116,18 @@ const Multichart: FunctionComponent<MultichartProperties> = ({ chartConfigs, cha
       }
     }
   }, [inView]);
+
+  useEffect(() => {
+    if (chartRenderer && chartRenderer.rendered) {
+      const isMobile = width < pxToNumber(breakpointLg);
+      chartRenderer.chartConfigs.forEach(config => {
+        if (config.data) {
+          config.options.xAxisTickValues = config.data.map(d => new Date(d[config.dateField])).filter((_, i) => (isMobile ? i % 3 === 0 : true));
+        }
+      });
+      chartRenderer.generateChart();
+    }
+  }, [width]);
 
   return (
     <>

--- a/src/layouts/explainer/sections/national-debt/breaking-down-the-debt/breaking-down-the-debt.jsx
+++ b/src/layouts/explainer/sections/national-debt/breaking-down-the-debt/breaking-down-the-debt.jsx
@@ -180,7 +180,7 @@ const BreakingDownTheDebt = ({ sectionId }) => {
               const xAxisTickValues = [];
               for (let i = 0, il = response.data.length; i < il; i += 1) {
                 const tickValue = new Date(response.data[i][chartConfig.dateField]);
-                xAxisTickValues.push(tickValue);
+                xAxisTickValues.push(tickValue); // all tick values added as xAxis labels
               }
               chartConfig.options.xAxisTickValues = xAxisTickValues;
               chartConfig.data = response.data;
@@ -372,7 +372,7 @@ const BreakingDownTheDebt = ({ sectionId }) => {
                 </div>
               ) : (
                 <div className={`${multichartContainer} multichart-scaled`}>
-                  <Multichart chartId={multichartId} chartConfigs={multichartConfigs} hoverEffectHandler={hoverEffectHandler} width={width} />
+                  <Multichart chartId={multichartId} chartConfigs={multichartConfigs} hoverEffectHandler={hoverEffectHandler} />
                 </div>
               )}
               <div className={multichartLegend} data-testid="interest-and-debt-chart-legend">

--- a/src/layouts/explainer/sections/national-debt/breaking-down-the-debt/breaking-down-the-debt.jsx
+++ b/src/layouts/explainer/sections/national-debt/breaking-down-the-debt/breaking-down-the-debt.jsx
@@ -372,7 +372,7 @@ const BreakingDownTheDebt = ({ sectionId }) => {
                 </div>
               ) : (
                 <div className={`${multichartContainer} multichart-scaled`}>
-                  <Multichart chartId={multichartId} chartConfigs={multichartConfigs} hoverEffectHandler={hoverEffectHandler} />
+                  <Multichart chartId={multichartId} chartConfigs={multichartConfigs} hoverEffectHandler={hoverEffectHandler} width={width} />
                 </div>
               )}
               <div className={multichartLegend} data-testid="interest-and-debt-chart-legend">

--- a/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-trends-over-time/debt-trends-over-time-chart.jsx
+++ b/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-trends-over-time/debt-trends-over-time-chart.jsx
@@ -242,7 +242,7 @@ export const DebtTrendsOverTimeChart = ({ sectionId, beaGDPData, width }) => {
                       tickSize: 6,
                       tickPadding: 8,
                       tickRotation: 0,
-                      tickValues: width < pxToNumber(breakpointLg) ? [1940, 1970, 2000, 2030] : 9,
+                      tickValues: width < pxToNumber(breakpointLg) ? [1940, 1955, 1970, 1985, 2000, 2015, 2030] : 9,
                     }}
                     axisLeft={{
                       format: formatPercentage,

--- a/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-trends-over-time/debt-trends-over-time-chart.jsx
+++ b/src/layouts/explainer/sections/national-debt/growing-national-debt/debt-trends-over-time/debt-trends-over-time-chart.jsx
@@ -242,7 +242,7 @@ export const DebtTrendsOverTimeChart = ({ sectionId, beaGDPData, width }) => {
                       tickSize: 6,
                       tickPadding: 8,
                       tickRotation: 0,
-                      tickValues: 9,
+                      tickValues: width < pxToNumber(breakpointLg) ? [1940, 1970, 2000, 2030] : 9,
                     }}
                     axisLeft={{
                       format: formatPercentage,

--- a/src/layouts/explainer/sections/treasury-savings-bonds/purchase-of-savings-bonds/savings-bonds-sold-by-type-chart/savings-bonds-sold-by-type-chart.spec.js
+++ b/src/layouts/explainer/sections/treasury-savings-bonds/purchase-of-savings-bonds/savings-bonds-sold-by-type-chart/savings-bonds-sold-by-type-chart.spec.js
@@ -148,7 +148,7 @@ describe('Savings Bonds by Type Over Time Chart', () => {
     );
     expect(await findByText('$125.0 B')).toBeInTheDocument();
 
-    const inflationToggle = getByRole('checkbox', { name: 'inflation toggle switch active: false' });
+    const inflationToggle = getByRole('switch', { name: 'inflation toggle switch active: false' });
     fireEvent.click(inflationToggle);
 
     expect(gaSpy).toHaveBeenCalledWith({

--- a/src/layouts/explainer/sections/treasury-savings-bonds/purchase-of-savings-bonds/savings-bonds-sold-by-type-chart/savings-bonds-sold-by-type-chart.spec.js
+++ b/src/layouts/explainer/sections/treasury-savings-bonds/purchase-of-savings-bonds/savings-bonds-sold-by-type-chart/savings-bonds-sold-by-type-chart.spec.js
@@ -148,7 +148,7 @@ describe('Savings Bonds by Type Over Time Chart', () => {
     );
     expect(await findByText('$125.0 B')).toBeInTheDocument();
 
-    const inflationToggle = getByRole('switch', { name: 'inflation toggle switch active: false' });
+    const inflationToggle = getByRole('checkbox', { name: 'inflation toggle switch active: false' });
     fireEvent.click(inflationToggle);
 
     expect(gaSpy).toHaveBeenCalledWith({


### PR DESCRIPTION
**JIRA Ticket:**

[FDG-11192](https://federal-spending-transparency.atlassian.net/browse/FDG-11192)

***The following are ALL required for the PR to be merged:***

- [ ] Provided testing instructions in JIRA ticket `if applicable`
- [ ] Provided mocks or additional information in JIRA ticket `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [ ] Verify all files are covered by at least 93% test coverage `if applicable`
- [ ] Verify that dashes are used for any visible defaults of evergreen values `if applicable`
- [ ] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
