### PR TITLE
FDG-11794 Savings Bond page "Savings Bonds Sold as a Percentage of Total Debt Held by the Public, as of May 2026" is not displaying the chart

### DIFF
--- a/src/layouts/explainer/sections/treasury-savings-bonds/how-savings-bonds-finance-government/how-savings-bonds-finance-government.spec.js
+++ b/src/layouts/explainer/sections/treasury-savings-bonds/how-savings-bonds-finance-government/how-savings-bonds-finance-government.spec.js
@@ -72,18 +72,12 @@ describe('How Savings Bonds Finance The Government Section', () => {
         'begin:https://www.transparency.treasury.gov/services/api/fiscal_service/v1/accounting/od/securities_sales?filter=security_type_desc:eq:Savings%20Bond',
         mockSavingsBondTypesData
       )
-      .route(
-        'https://www.transparency.treasury.gov/services/api/fiscal_service/v1/debt/mspd/mspd_table_1?filter=record_date:eq&page[size]=1',
-        mockMSPDData
-      )
+      .route('https://www.transparency.treasury.gov/services/api/fiscal_service/v1/debt/mspd/mspd_table_1?&page[size]=1', mockMSPDData)
       .route(
         'https://www.transparency.treasury.gov/services/api/fiscal_service/v1/debt/mspd/mspd_table_1?sort=-record_date&page[size]=1',
         mockMSPDData2
       )
-      .route(
-        'https://www.transparency.treasury.gov/services/api/fiscal_service/v1/debt/mspd/mspd_table_1?filter=record_date:eq&page[size]=30',
-        mockMSPDData2
-      );
+      .route('https://www.transparency.treasury.gov/services/api/fiscal_service/v1/debt/mspd/mspd_table_1?&page[size]=30', mockMSPDData2);
   });
 
   afterAll(() => {

--- a/src/layouts/explainer/sections/treasury-savings-bonds/how-savings-bonds-finance-government/how-savings-bonds-finance-government.tsx
+++ b/src/layouts/explainer/sections/treasury-savings-bonds/how-savings-bonds-finance-government/how-savings-bonds-finance-government.tsx
@@ -71,7 +71,7 @@ const HowSavingsBondsFinanceGovernment: FunctionComponent<{ width?: number }> = 
   );
 
   const savingsBondsByTypeHistorical = allSavingsBondsByTypeHistorical.allSavingsBondsByTypeHistoricalCsv.savingsBondsByTypeHistoricalCsv;
-  const howSavingBondsSold = 'v1/debt/mspd/mspd_table_1?filter=record_date:eq';
+  const howSavingBondsSold = 'v1/debt/mspd/mspd_table_1?';
 
   useEffect(() => {
     basicFetch(`${apiPrefix}${howSavingBondsSold}&page[size]=1`).then((metaRes: ApiResponse) => {


### PR DESCRIPTION
**JIRA Ticket:**

[FDG-11794](https://federal-spending-transparency.atlassian.net/browse/FDG-11794)

***The following are ALL required for the PR to be merged:***

- [ ] Provided testing instructions in JIRA ticket `if applicable`
- [ ] Provided mocks or additional information in JIRA ticket `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [ ] Verify all files are covered by at least 93% test coverage `if applicable`
- [ ] Verify that dashes are used for any visible defaults of evergreen values `if applicable`
- [ ] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
