### PR TITLE
FDG-11871 When the 'Rows Per Page' dropdown component is opened, the scroll bar for the entire page becomes disabled.

### DIFF
--- a/src/components/pagination/paging-options-menu.jsx
+++ b/src/components/pagination/paging-options-menu.jsx
@@ -55,6 +55,7 @@ const PagingOptionsMenu = ({ menuProps }) => {
         anchorEl={anchorElement}
         keepMounted
         disablePortal
+        disableScrollLock
         open={Boolean(anchorElement)}
         onClose={() => handleCloseOrChange(selectedOption)}
       >


### PR DESCRIPTION
**JIRA Ticket:**

[FDG-11887](https://federal-spending-transparency.atlassian.net/browse/FDG-11887)

***The following are ALL required for the PR to be merged:***

- [ ] Provided testing instructions in JIRA ticket `if applicable`
- [ ] Provided mocks or additional information in JIRA ticket `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [ ] Verify all files are covered by at least 93% test coverage `if applicable`
- [ ] Verify that dashes are used for any visible defaults of evergreen values `if applicable`
- [ ] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
