### PR TITLE
FDG-11887 When the 'Rows Per Page' dropdown component is opened, the scroll bar for the entire page becomes disabled.

### DIFF
--- a/src/components/pagination/paging-options-menu.jsx
+++ b/src/components/pagination/paging-options-menu.jsx
@@ -55,6 +55,7 @@ const PagingOptionsMenu = ({ menuProps }) => {
         anchorEl={anchorElement}
         keepMounted
         disablePortal
+        disableScrollLock
         open={Boolean(anchorElement)}
         onClose={() => handleCloseOrChange(selectedOption)}
       >

--- a/src/components/pagination/paging-options-menu.jsx
+++ b/src/components/pagination/paging-options-menu.jsx
@@ -18,6 +18,13 @@ const PagingOptionsMenu = ({ menuProps }) => {
     }
   }, [selected]);
 
+  useEffect(() => {
+    if (!anchorElement) return;
+    const handleScroll = () => setAnchorElement(null);
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [anchorElement]);
+
   const handleOpen = event => {
     setAnchorElement(event.currentTarget);
   };

--- a/src/components/pagination/paging-options-menu.jsx
+++ b/src/components/pagination/paging-options-menu.jsx
@@ -11,6 +11,7 @@ const PagingOptionsMenu = ({ menuProps }) => {
 
   const [anchorElement, setAnchorElement] = useState(null);
   const [selectedOption, setSelectedOption] = useState(selected);
+  const [open, setOpen] = React.useState(false);
 
   useEffect(() => {
     if (label === 'Go to Page' && selected !== selectedOption) {
@@ -19,18 +20,19 @@ const PagingOptionsMenu = ({ menuProps }) => {
   }, [selected]);
 
   useEffect(() => {
-    if (!anchorElement) return;
-    const handleScroll = () => setAnchorElement(null);
+    if (!open) return;
+    const handleScroll = () => setOpen(false);
     window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
-  }, [anchorElement]);
+  }, [open]);
 
   const handleOpen = event => {
     setAnchorElement(event.currentTarget);
+    setOpen(true);
   };
 
   const handleCloseOrChange = value => {
-    setAnchorElement(null);
+    setOpen(false);
     setSelectedOption(value);
     if (updateSelected) {
       updateSelected(value);
@@ -52,7 +54,7 @@ const PagingOptionsMenu = ({ menuProps }) => {
         aria-label="rows-per-page-menu"
         onClick={handleOpen}
         variant="outlined"
-        endIcon={anchorElement === null ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+        endIcon={open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
         disabled={disabled}
       >
         {selectedOption}
@@ -63,7 +65,7 @@ const PagingOptionsMenu = ({ menuProps }) => {
         keepMounted
         disablePortal
         disableScrollLock
-        open={Boolean(anchorElement)}
+        open={open}
         onClose={() => handleCloseOrChange(selectedOption)}
       >
         {renderMenuItems()}


### PR DESCRIPTION
**JIRA Ticket:**

[FDG-11887](https://federal-spending-transparency.atlassian.net/browse/FDG-11887)

***The following are ALL required for the PR to be merged:***

- [ ] Provided testing instructions in JIRA ticket `if applicable`
- [ ] Provided mocks or additional information in JIRA ticket `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [ ] Verify all files are covered by at least 93% test coverage `if applicable`
- [ ] Verify that dashes are used for any visible defaults of evergreen values `if applicable`
- [ ] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
