### PR TITLE
FDG-11895 Migrate 'Federal Revenue and the U.S. Economy' Chart from Nivo to Recharts

### DIFF
--- a/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.jsx
+++ b/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.jsx
@@ -1,25 +1,20 @@
 import React, { useEffect, useState } from 'react';
-import { Line } from '@nivo/line';
-import { pxToNumber } from '../../../../../../../helpers/styles-helper/styles-helper';
 import ChartContainer from '../../../../../explainer-components/chart-container/chart-container';
-import { breakpointLg, fontSize_10 } from '../../../../../../../variables.module.scss';
-import { chartConfigs, dataHeader, getChartCopy, getMarkers } from './total-revenue-chart-helper';
+import { dataHeader, getChartCopy } from './total-revenue-chart-helper';
 import { visWithCallout } from '../../../../../explainer.module.scss';
-import VisualizationCallout from '../../../../../../../components/visualization-callout/visualization-callout';
-import { container, lineChart } from './total-revenue-chart.module.scss';
+import VisualizationCallout
+  from '../../../../../../../components/visualization-callout/visualization-callout';
+import { container, lineChart, loadingIcon } from './total-revenue-chart.module.scss';
 import { revenueExplainerPrimary } from '../../../revenue.module.scss';
 import {
   addInnerChartAriaLabel,
   applyChartScaling,
-  applyTextScaling,
-  chartInViewProps,
-  getChartTheme,
-  LineChartCustomPoints_GDP,
-  nivoCommonLineChartProps,
+  chartInViewProps
 } from '../../../../../explainer-helpers/explainer-charting-helper';
-import CustomSlices from '../../../../../../../components/nivo/custom-slice/custom-slice';
 import { apiPrefix, basicFetch } from '../../../../../../../utils/api-utils';
-import { adjustDataForInflation } from '../../../../../../../helpers/inflation-adjust/inflation-adjust';
+import {
+  adjustDataForInflation
+} from '../../../../../../../helpers/inflation-adjust/inflation-adjust';
 import simplifyNumber from '../../../../../../../helpers/simplify-number/simplifyNumber';
 import numeral from 'numeral';
 import { getShortForm } from '../../../../../../../utils/rounding-utils';
@@ -27,9 +22,17 @@ import { getDateWithoutTimeZoneAdjust } from '../../../../../../../utils/date-ut
 import Analytics from '../../../../../../../utils/analytics/analytics';
 import { useInView } from 'react-intersection-observer';
 import LoadingIndicator from '../../../../../../../components/loading-indicator/loading-indicator';
-import { loadingIcon } from './total-revenue-chart.module.scss';
 import { useErrorBoundary } from 'react-error-boundary';
-import { useWindowSize } from 'usehooks-ts';
+import {
+  Line,
+  LineChart,
+  ReferenceDot,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+import Point from '../../../../../../../components/nivo/custom-point/point';
 
 let gaTimerTotalRevenue;
 let ga4Timer;
@@ -41,38 +44,54 @@ const chartDataEndPoint = apiPrefix + 'v1/accounting/mts/mts_table_4?filter=line
 
 const TotalRevenueChart = ({ cpiDataByYear, beaGDPData, copyPageData }) => {
   const [revenueChartData, setRevenueChartData] = useState([]);
-  const { width } = useWindowSize();
   const [gdpChartData, setGdpChartData] = useState([]);
   const [gdpRatioChartData, setRatioGdpChartData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [minYear, setMinYear] = useState('');
   const [maxYear, setMaxYear] = useState('');
+  const [maxAmount, setMaxAmount] = useState(0);
   const [callOutYear, setCallOutYear] = useState('');
   const [lastRatio, setLastRatio] = useState('');
   const [lastUpdatedDate, setLastUpdatedDate] = useState(null);
   const [lastGDPValue, setLastGDPValue] = useState('');
   const [lastRevenueValue, setLastRevenueValue] = useState('');
-  const [maxRevenueValue, setMaxRevenueValue] = useState(0);
-  const [maxGDPValue, setMaxGDPValue] = useState(0);
   const [selectedChartView, setSelectedChartView] = useState('totalRevenue');
+
   const [animationTriggeredOnce, setAnimationTriggeredOnce] = useState(false);
   const [secondaryAnimationTriggeredOnce, setSecondaryAnimationTriggeredOnce] = useState(false);
+  const [animationComplete, setAnimationComplete] = useState(false);
+  const [secondaryAnimationComplete, setSecondaryAnimationComplete] = useState(false);
+
+  const [chartFocus, setChartFocus] = useState(false);
+  const [chartHover, setChartHover] = useState(false);
+  const [chartActive, setChartActive] = useState(false);
+
   const [calloutCopy, setCalloutCopy] = useState('');
-  const [revenueHoverDisabled, setRevenueHoverDisabled] = useState(true);
-  const [gdpHoverDisabled, setGdpHoverDisabled] = useState(true);
-  const [totalRevenueHeadingValues, setTotalRevenueHeadingValues] = useState({
-    fiscalYear: '--',
-    totalRevenue: '',
-    gdp: '',
-    gdpRatio: '',
-  });
+
+  const [curFY, setCurFY] = useState('--');
+  const [curRevenue, setCurRevenue] = useState();
+  const [curGDP, setCurGDP] = useState();
+  const [curPercentGDP, setCurPercentGDP] = useState();
+
+  const [defaultIndex, setDefaultIndex] = useState(0);
+  const [secondaryDefaultIndex, setSecondaryDefaultIndex] = useState(0);
 
   const { ref: revenueRef, inView: revenueInView } = useInView(chartInViewProps);
   const { ref: gdpRef, inView: gdpInView } = useInView(chartInViewProps);
 
   const { showBoundary } = useErrorBoundary();
 
+  const chartTheme = {
+    height: 418,
+    margin: { top: 12, bottom: 0, left: -12, right: 12 },
+    axis: { fontSize: 14 },
+    tick: { fill: '#555' },
+    line: { stroke: '#666' },
+    cursor: { strokeDasharray: '6 6', stroke: '#555', strokeWidth: 2 },
+  };
+
   const handleMouseEnterChart = () => {
+    setChartHover(true);
     gaTimerTotalRevenue = setTimeout(() => {
       Analytics.event({
         category: 'Explainers',
@@ -92,27 +111,6 @@ const TotalRevenueChart = ({ cpiDataByYear, beaGDPData, copyPageData }) => {
     clearTimeout(gaTimerTotalRevenue);
     clearTimeout(ga4Timer);
   };
-
-  const percentageData = [
-    {
-      id: 'GDP Percentage',
-      color: '#666666',
-      data: gdpRatioChartData,
-    },
-  ];
-  const totalData = [
-    {
-      id: 'GDP',
-      color: '#666666',
-      data: gdpChartData,
-    },
-    {
-      id: 'Total Revenue',
-      color: '#666666',
-      data: revenueChartData,
-    },
-  ];
-  const [chartData, setChartData] = useState(totalData);
 
   const chartParent = 'totalRevenueChartParent';
   const chartWidth = 550;
@@ -148,7 +146,7 @@ const TotalRevenueChart = ({ cpiDataByYear, beaGDPData, copyPageData }) => {
             if (parseInt(revenue.record_fiscal_year) <= gdpMaxYear)
               finalRevenueChartData.push({
                 x: parseInt(revenue.record_fiscal_year),
-                actual: parseInt(revenue.current_fytd_net_rcpt_amt),
+                actual_revenue: parseInt(revenue.current_fytd_net_rcpt_amt),
                 fiscalYear: revenue.record_fiscal_year,
                 record_date: revenue.record_date,
               });
@@ -156,10 +154,10 @@ const TotalRevenueChart = ({ cpiDataByYear, beaGDPData, copyPageData }) => {
 
           finalRevenueChartData = finalRevenueChartData.filter(s => s.x <= gdpMaxYear);
 
-          finalRevenueChartData = adjustDataForInflation(finalRevenueChartData, 'actual', 'fiscalYear', cpiDataByYear);
+          finalRevenueChartData = adjustDataForInflation(finalRevenueChartData, 'actual_revenue', 'fiscalYear', cpiDataByYear);
 
           finalRevenueChartData.forEach(revenue => {
-            revenue.y = parseFloat(simplifyNumber(revenue.actual, false).slice(0, -2));
+            revenue.revenue_y = parseFloat(simplifyNumber(revenue.actual_revenue, false).slice(0, -2));
           });
 
           setRevenueChartData(finalRevenueChartData);
@@ -170,60 +168,72 @@ const TotalRevenueChart = ({ cpiDataByYear, beaGDPData, copyPageData }) => {
           const revenueMinYear = finalRevenueChartData.reduce((min, revenue) => (min.x < revenue.x ? min : revenue));
           setMinYear(revenueMinYear.x);
 
-          const revenueMaxAmount = finalRevenueChartData.reduce((min, revenue) => (min.y > revenue.y ? min : revenue));
+          const revenueMaxAmount = finalRevenueChartData.reduce((min, revenue) => (min.revenue_y > revenue.revenue_y ? min : revenue));
 
-          const revenueLastAmountActual = finalRevenueChartData[finalRevenueChartData.length - 1].actual;
+          const revenueLastAmountActual = finalRevenueChartData[finalRevenueChartData.length - 1].actual_revenue;
 
-          setLastRevenueValue(revenueLastAmountActual);
-
-          setMaxRevenueValue(revenueMaxAmount.y);
+          setLastRevenueValue(finalRevenueChartData[finalRevenueChartData.length - 1].revenue_y);
 
           const lastUpdatedDateRevenue = new Date(finalRevenueChartData[finalRevenueChartData.length - 1].record_date);
           setLastUpdatedDate(getDateWithoutTimeZoneAdjust(lastUpdatedDateRevenue));
 
           const filteredGDPData = finalGDPData.filter(g => g.fiscalYear <= revenueMaxYear.x && g.fiscalYear >= revenueMinYear.x);
-
+          const filteredGDPData_chartData = [];
+          filteredGDPData.forEach(data => {
+            filteredGDPData_chartData.push({ actual_gdp: data.actual, gdp_y: data.y, x: data.x, fiscalYear: data.fiscalYear });
+          });
           const finalGdpRatioChartData = [];
           finalRevenueChartData.forEach(revenue => {
             const revenueYear = revenue.fiscalYear;
-            const revenueAmount = revenue.y;
-            const matchingGDP = filteredGDPData.filter(g => g.fiscalYear === revenueYear).map(g => g.y);
-            const gdpRatio = numeral(revenueAmount / matchingGDP).format('0%');
+            const revenueAmount = revenue.revenue_y;
+            const matchingGDP = filteredGDPData_chartData.filter(g => g.fiscalYear === revenueYear).map(g => g.gdp_y);
+            const gdpRatio = revenueAmount / matchingGDP;
             finalGdpRatioChartData.push({
-              x: revenueYear,
+              x: parseInt(revenueYear),
               y: gdpRatio,
             });
           });
 
           setRatioGdpChartData(finalGdpRatioChartData);
 
-          const chartFirstRatio = numeral(finalRevenueChartData[0].y / filteredGDPData[0].y).format('0%');
-          const chartLastRatio = numeral(
-            finalRevenueChartData[finalRevenueChartData.length - 1].y / filteredGDPData[filteredGDPData.length - 1].y
-          ).format('0%');
+          const chartFirstRatio = finalRevenueChartData[0].revenue_y / filteredGDPData_chartData[0].gdp_y;
+          const chartLastRatio =
+            finalRevenueChartData[finalRevenueChartData.length - 1].revenue_y / filteredGDPData_chartData[filteredGDPData_chartData.length - 1].gdp_y;
+
+          const firstRatio_formatted = numeral(chartFirstRatio).format('0%');
+          const lastRatio_formatted = numeral(chartLastRatio).format('0%');
+
           setLastRatio(chartLastRatio);
+
           if (chartFirstRatio !== chartLastRatio) {
             setCalloutCopy(
               `the Revenue-to-GDP ratio has ${
-                chartLastRatio > chartFirstRatio ? 'increased' : 'decreased'
-              } from ${chartFirstRatio} to ${chartLastRatio}`
+                lastRatio_formatted > firstRatio_formatted ? 'increased' : 'decreased'
+              } from ${firstRatio_formatted} to ${lastRatio_formatted}`
             );
           } else {
-            setCalloutCopy(`the Revenue-to-GDP ratio has not changed, remaining at ${chartFirstRatio}`);
+            setCalloutCopy(`the Revenue-to-GDP ratio has not changed, remaining at ${firstRatio_formatted}`);
           }
 
-          const chartMaxGDPValue = filteredGDPData.reduce((max, gdp) => (max.x > gdp.x ? max.y : gdp.y));
-          const chartLastGDPValue = filteredGDPData[filteredGDPData.length - 1].actual;
-          setLastGDPValue(chartLastGDPValue);
-          setGdpChartData(filteredGDPData);
+          const chartMaxGDPValue = filteredGDPData_chartData.reduce((max, gdp) => (max.x > gdp.x ? max.gdp_y : gdp.gdp_y));
+          const chartLastGDPValue = filteredGDPData_chartData[filteredGDPData_chartData.length - 1].actual_gdp;
+          setLastGDPValue(filteredGDPData_chartData[filteredGDPData_chartData.length - 1].gdp_y);
 
-          setMaxGDPValue(chartMaxGDPValue);
-          setTotalRevenueHeadingValues({
-            fiscalYear: revenueMaxYear.x,
-            totalRevenue: simplifyNumber(revenueLastAmountActual, false),
-            gdp: simplifyNumber(chartLastGDPValue, false),
-            gdpRatio: chartLastRatio,
+          const maxAmountLocal = Math.ceil((revenueMaxAmount > chartMaxGDPValue ? revenueMaxAmount : chartMaxGDPValue) / 5) * 5;
+          setMaxAmount(maxAmountLocal);
+
+          setCurFY(revenueMaxYear.x);
+          setCurFY(revenueMaxYear.x);
+          setCurRevenue(simplifyNumber(revenueLastAmountActual, false));
+          setCurGDP(simplifyNumber(chartLastGDPValue, false));
+          setCurPercentGDP(chartLastRatio);
+
+          const chartData_combined = [];
+          filteredGDPData_chartData.forEach((data, index) => {
+            chartData_combined.push({ ...data, ...finalRevenueChartData[index] });
           });
+          setGdpChartData(chartData_combined);
+          console.log(chartData_combined);
 
           copyPageData({
             fiscalYear: revenueMaxYear.x,
@@ -241,51 +251,11 @@ const TotalRevenueChart = ({ cpiDataByYear, beaGDPData, copyPageData }) => {
       });
   }, []);
 
-  useEffect(() => {
-    applyTextScaling(chartParent, chartWidth, width, fontSize_10);
-  }, [width, chartToggleConfig]);
-
-  useEffect(() => {
-    if (!selectedChartView) return;
-    if (selectedChartView === 'percentageGdp') {
-      setChartData(percentageData);
-    }
-    if (selectedChartView === 'totalRevenue' && gdpChartData.length && revenueChartData.length) {
-      setChartData(totalData);
-    }
-  }, [selectedChartView, gdpChartData, revenueChartData]);
-
   const handleGroupOnMouseLeave = () => {
-    setTotalRevenueHeadingValues({
-      fiscalYear: maxYear,
-      totalRevenue: simplifyNumber(lastRevenueValue, false),
-      gdp: simplifyNumber(lastGDPValue, false),
-      gdpRatio: lastRatio,
-    });
-  };
-
-  const handleMouseLeave = slice => {
-    if (selectedChartView === 'totalRevenue') {
-      const revenueData = slice.points[0]?.data;
-      const gdpData = slice.points[1]?.data;
-      if (revenueData && gdpData) {
-        setTotalRevenueHeadingValues({
-          ...totalRevenueHeadingValues,
-          totalRevenue: simplifyNumber(revenueData.actual, false),
-          fiscalYear: revenueData.fiscalYear,
-          gdp: simplifyNumber(gdpData.actual, false),
-        });
-      }
-    } else if (selectedChartView === 'percentageGdp') {
-      const percentData = slice.points[0]?.data;
-      if (percentData) {
-        setTotalRevenueHeadingValues({
-          ...totalRevenueHeadingValues,
-          fiscalYear: percentData.x,
-          gdpRatio: percentData.y + '%',
-        });
-      }
-    }
+    setCurFY(maxYear.toString());
+    setCurRevenue(lastRevenueValue + ' T');
+    setCurGDP(lastGDPValue + ' T');
+    setCurPercentGDP(lastRatio);
   };
 
   const { title: chartTitle, subtitle: chartSubtitle, footer: chartFooter, altText: chartAltText } = getChartCopy(
@@ -294,100 +264,210 @@ const TotalRevenueChart = ({ cpiDataByYear, beaGDPData, copyPageData }) => {
     selectedChartView
   );
 
-  const xScale = {
-    type: 'linear',
-    min: minYear,
-    max: maxYear,
-  };
-  const yScale = {
-    type: 'linear',
-    min: 0,
-    max: 30,
-    stacked: false,
-    reverse: false,
+  const updateDataHeader = payload => {
+    if (selectedChartView === 'totalRevenue') {
+      const revenueData = payload[0]?.payload?.actual_revenue;
+      const gdpData = payload[0]?.payload?.actual_gdp;
+      if (revenueData && gdpData) {
+        setCurFY(payload[0].payload.fiscalYear);
+        setCurRevenue(simplifyNumber(revenueData, false));
+        setCurGDP(simplifyNumber(gdpData, false));
+      }
+    } else if (selectedChartView === 'percentageGdp') {
+      const percentData = payload[0]?.payload?.y;
+      if (percentData) {
+        setCurFY(payload[0]?.payload?.x);
+        setCurPercentGDP(percentData);
+      }
+    }
   };
 
-  const commonProps = {
-    ...nivoCommonLineChartProps,
-    data: chartData,
-    colors: d => d.color,
-    width: chartWidth,
-    height: chartHeight,
-    axisBottom: chartConfigs.axisBottom,
-    axisLeft: selectedChartView === 'totalRevenue' ? chartConfigs.axisLeftTotalRevenue : chartConfigs.axisLeftPercentageGDP,
-    useMesh: false,
-    markers: getMarkers(width, selectedChartView, maxGDPValue, maxRevenueValue),
-    margin: width < pxToNumber(breakpointLg) ? { top: 25, right: 25, bottom: 30, left: 55 } : { top: 20, right: 15, bottom: 35, left: 50 },
-    theme: getChartTheme(width, true),
-    xScale: xScale,
-    yScale: yScale,
+  const CustomTooltip = ({ payload = [] }) => {
+    if (payload.length > 0) {
+      updateDataHeader(payload);
+    }
+    return <></>;
   };
+
+  const HoverPoint = payload => {
+    const { cx, cy, strokeWidth, label, active } = payload;
+    return (
+      <g data-testid="customPoints">
+        {payload?.cx && <Point currentPoint={{ x: cx, y: cy, r: 1.5, strokeWidth: strokeWidth, opacity: !active && chartActive ? 0 : 1 }} />}
+        {label && (
+          <text
+            x={cx - 5}
+            y={cy + 30}
+            style={{ fontSize: '12px', fontFamily: '"Source Sans Pro", sans-serif', fill: '#666', fontWeight: '600', textAnchor: 'end' }}
+          >
+            {label}
+          </text>
+        )}
+      </g>
+    );
+  };
+
+  useEffect(() => {
+    if (revenueInView && gdpChartData.length && !animationTriggeredOnce) {
+      setAnimationTriggeredOnce(true);
+      const stepDuration = 500;
+      const timers = [];
+
+      gdpChartData.forEach((slice, index) => {
+        timers.push(
+          setTimeout(() => {
+            setDefaultIndex(index);
+          }, stepDuration * index + 550)
+        );
+      });
+      setTimeout(() => {
+        setAnimationComplete(true);
+      }, stepDuration * gdpChartData.length + 550);
+      return () => {
+        timers.forEach(timer => clearTimeout(timer));
+      };
+    }
+  }, [revenueInView, gdpChartData]);
+
+  useEffect(() => {
+    if (gdpInView && gdpRatioChartData.length && !secondaryAnimationTriggeredOnce) {
+      setSecondaryAnimationTriggeredOnce(true);
+      const stepDuration = 500;
+      const timers = [];
+
+      gdpRatioChartData.forEach((slice, index) => {
+        timers.push(
+          setTimeout(() => {
+            setSecondaryDefaultIndex(index);
+          }, stepDuration * index + 550)
+        );
+      });
+      setTimeout(() => {
+        setSecondaryAnimationComplete(true);
+      }, stepDuration * gdpChartData.length + 550);
+      return () => {
+        timers.forEach(timer => clearTimeout(timer));
+      };
+    }
+  }, [gdpInView, gdpRatioChartData]);
+
+  useEffect(() => {
+    setChartActive(chartFocus || chartHover || (selectedChartView === 'totalRevenue' ? !animationComplete : !secondaryAnimationComplete));
+  }, [chartHover, chartFocus, animationComplete, secondaryAnimationComplete, selectedChartView]);
+
+  useEffect(() => {
+    if (!chartActive && (selectedChartView === 'totalRevenue' ? animationComplete : secondaryAnimationComplete)) {
+      handleGroupOnMouseLeave();
+    }
+  }, [chartActive]);
 
   return (
     <>
       <figure className={visWithCallout}>
-        <div className={container} role="presentation" onMouseEnter={handleMouseEnterChart} onMouseLeave={handleMouseLeaveChart}>
+        <div className={container}>
           <ChartContainer
             title={chartTitle}
             subTitle={chartSubtitle}
             footer={chartFooter}
             date={lastUpdatedDate}
-            header={dataHeader(chartToggleConfig, totalRevenueHeadingValues)}
+            header={dataHeader(chartToggleConfig, {
+              fiscalYear: curFY,
+              totalRevenue: curRevenue,
+              gdp: curGDP,
+              gdpRatio: numeral(curPercentGDP).format('0%'),
+            })}
             altText={chartAltText}
           >
             {isLoading && <LoadingIndicator loadingClass={loadingIcon} />}
             {!isLoading && chartToggleConfig && (
-              <div className={lineChart} data-testid="totalRevenueChartParent">
+              <div
+                className={lineChart}
+                data-testid="totalRevenueChartParent"
+                role="presentation"
+                onMouseEnter={handleMouseEnterChart}
+                onFocus={() => setChartFocus(true)}
+                onBlur={() => setChartFocus(false)}
+                onMouseLeave={() => {
+                  setChartHover(false);
+                  handleMouseLeaveChart();
+                }}
+              >
                 {selectedChartView === 'totalRevenue' && (
-                  <div data-testid="revenueLineChart" ref={revenueRef} style={{ pointerEvents: revenueHoverDisabled ? 'none' : 'auto' }}>
-                    <Line
-                      {...commonProps}
-                      layers={[
-                        ...chartConfigs.layers,
-                        props =>
-                          LineChartCustomPoints_GDP({
-                            ...props,
-                            seriesId: 'Total Revenue',
-                          }),
-                        props =>
-                          CustomSlices({
-                            ...props,
-                            groupMouseLeave: handleGroupOnMouseLeave,
-                            mouseMove: handleMouseLeave,
-                            inView: revenueInView,
-                            duration: 450,
-                            customAnimationTriggeredOnce: animationTriggeredOnce,
-                            setCustomAnimationTriggeredOnce: setAnimationTriggeredOnce,
-                            onAnimationComplete: () => setRevenueHoverDisabled(false),
-                          }),
-                      ]}
-                    />
+                  <div data-testid="revenueLineChart" ref={revenueRef} style={{ pointerEvents: !animationComplete ? 'none' : 'auto' }}>
+                    <ResponsiveContainer height={chartTheme.height} width="99%">
+                      <LineChart data={gdpChartData} margin={chartTheme.margin} accessibilityLayer>
+                        <XAxis dataKey="x" fontSize={chartTheme.axis.fontSize} tick={{ ...chartTheme.axis.tick }} />
+                        <YAxis
+                          tick={{ ...chartTheme.axis.tick }}
+                          fontSize={chartTheme.axis.fontSize}
+                          domain={[0, maxAmount]}
+                          tickFormatter={value => (value > 0 ? '$' + value + ' T' : '$' + value)}
+                          tickCount={8}
+                        />
+                        <Line
+                          dataKey="revenue_y"
+                          stroke={chartTheme.line.stroke}
+                          dot={false}
+                          strokeWidth={2}
+                          activeDot={chartActive && <HoverPoint active={true} />}
+                          isAnimationActive={false}
+                        />
+                        <Line
+                          dataKey="gdp_y"
+                          stroke={chartTheme.line.stroke}
+                          dot={false}
+                          strokeWidth={2}
+                          activeDot={chartActive && <HoverPoint active={true} />}
+                          isAnimationActive={false}
+                        />
+                        <Tooltip
+                          content={<CustomTooltip />}
+                          cursor={{
+                            ...chartTheme.cursor,
+                            opacity: chartActive ? 0.75 : 0,
+                          }}
+                          isAnimationActive={false}
+                          active={chartActive}
+                          defaultIndex={defaultIndex}
+                        />
+                        <ReferenceDot x={maxYear} y={lastRevenueValue} shape={<HoverPoint label="Total Revenue" />} />
+                        <ReferenceDot x={maxYear} y={lastGDPValue} shape={<HoverPoint label="GDP" />} />
+                      </LineChart>
+                    </ResponsiveContainer>
                   </div>
                 )}
                 {selectedChartView === 'percentageGdp' && (
-                  <div ref={gdpRef} style={{ pointerEvents: gdpHoverDisabled ? 'none' : 'auto' }}>
-                    <Line
-                      {...commonProps}
-                      layers={[
-                        ...chartConfigs.layers,
-                        props =>
-                          LineChartCustomPoints_GDP({
-                            ...props,
-                            seriesId: 'Total Revenue',
-                          }),
-                        props =>
-                          CustomSlices({
-                            ...props,
-                            groupMouseLeave: handleGroupOnMouseLeave,
-                            mouseMove: handleMouseLeave,
-                            inView: gdpInView,
-                            duration: 450,
-                            customAnimationTriggeredOnce: secondaryAnimationTriggeredOnce,
-                            setCustomAnimationTriggeredOnce: setSecondaryAnimationTriggeredOnce,
-                            onAnimationComplete: () => setGdpHoverDisabled(false),
-                          }),
-                      ]}
-                    />
+                  <div ref={gdpRef} style={{ pointerEvents: !secondaryAnimationComplete ? 'none' : 'auto' }}>
+                    <ResponsiveContainer height={chartTheme.height} width="99%">
+                      <LineChart data={gdpRatioChartData} margin={chartTheme.margin} accessibilityLayer>
+                        <XAxis dataKey="x" fontSize={chartTheme.axis.fontSize} tick={{ ...chartTheme.axis.tick }} />
+                        <YAxis
+                          ticks={[0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3]}
+                          fontSize={chartTheme.axis.fontSize}
+                          tickFormatter={val => val * 100 + '%'}
+                          tick={{ ...chartTheme.axis.tick }}
+                        />
+                        <Line
+                          dataKey="y"
+                          stroke={chartTheme.line.stroke}
+                          dot={false}
+                          strokeWidth={2}
+                          activeDot={chartActive && <HoverPoint active={true} />}
+                          isAnimationActive={false}
+                        />
+                        <Tooltip
+                          content={<CustomTooltip />}
+                          cursor={{
+                            ...chartTheme.cursor,
+                            opacity: chartActive ? 0.75 : 0,
+                          }}
+                          isAnimationActive={false}
+                          active={chartActive}
+                          defaultIndex={secondaryDefaultIndex}
+                        />
+                        <ReferenceDot x={maxYear} y={lastRatio} shape={<HoverPoint />} />
+                      </LineChart>
+                    </ResponsiveContainer>
                   </div>
                 )}
               </div>

--- a/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.jsx
+++ b/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.jsx
@@ -2,19 +2,12 @@ import React, { useEffect, useState } from 'react';
 import ChartContainer from '../../../../../explainer-components/chart-container/chart-container';
 import { dataHeader, getChartCopy } from './total-revenue-chart-helper';
 import { visWithCallout } from '../../../../../explainer.module.scss';
-import VisualizationCallout
-  from '../../../../../../../components/visualization-callout/visualization-callout';
+import VisualizationCallout from '../../../../../../../components/visualization-callout/visualization-callout';
 import { container, lineChart, loadingIcon } from './total-revenue-chart.module.scss';
 import { revenueExplainerPrimary } from '../../../revenue.module.scss';
-import {
-  addInnerChartAriaLabel,
-  applyChartScaling,
-  chartInViewProps
-} from '../../../../../explainer-helpers/explainer-charting-helper';
+import { addInnerChartAriaLabel, applyChartScaling, chartInViewProps } from '../../../../../explainer-helpers/explainer-charting-helper';
 import { apiPrefix, basicFetch } from '../../../../../../../utils/api-utils';
-import {
-  adjustDataForInflation
-} from '../../../../../../../helpers/inflation-adjust/inflation-adjust';
+import { adjustDataForInflation } from '../../../../../../../helpers/inflation-adjust/inflation-adjust';
 import simplifyNumber from '../../../../../../../helpers/simplify-number/simplifyNumber';
 import numeral from 'numeral';
 import { getShortForm } from '../../../../../../../utils/rounding-utils';
@@ -23,15 +16,7 @@ import Analytics from '../../../../../../../utils/analytics/analytics';
 import { useInView } from 'react-intersection-observer';
 import LoadingIndicator from '../../../../../../../components/loading-indicator/loading-indicator';
 import { useErrorBoundary } from 'react-error-boundary';
-import {
-  Line,
-  LineChart,
-  ReferenceDot,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis
-} from 'recharts';
+import { Line, LineChart, ReferenceDot, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import Point from '../../../../../../../components/nivo/custom-point/point';
 
 let gaTimerTotalRevenue;
@@ -204,8 +189,7 @@ const TotalRevenueChart = ({ cpiDataByYear, beaGDPData, copyPageData }) => {
           const lastRatio_formatted = numeral(chartLastRatio).format('0%');
 
           setLastRatio(chartLastRatio);
-
-          if (chartFirstRatio !== chartLastRatio) {
+          if (firstRatio_formatted !== lastRatio_formatted) {
             setCalloutCopy(
               `the Revenue-to-GDP ratio has ${
                 lastRatio_formatted > firstRatio_formatted ? 'increased' : 'decreased'
@@ -233,7 +217,6 @@ const TotalRevenueChart = ({ cpiDataByYear, beaGDPData, copyPageData }) => {
             chartData_combined.push({ ...data, ...finalRevenueChartData[index] });
           });
           setGdpChartData(chartData_combined);
-          console.log(chartData_combined);
 
           copyPageData({
             fiscalYear: revenueMaxYear.x,
@@ -344,7 +327,7 @@ const TotalRevenueChart = ({ cpiDataByYear, beaGDPData, copyPageData }) => {
       });
       setTimeout(() => {
         setSecondaryAnimationComplete(true);
-      }, stepDuration * gdpChartData.length + 550);
+      }, stepDuration * gdpRatioChartData.length + 550);
       return () => {
         timers.forEach(timer => clearTimeout(timer));
       };

--- a/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.spec.js
+++ b/src/layouts/explainer/sections/government-revenue/federal-revenue-trends-and-us-economy/government-revenue-and-us-economy-chart/total-revenue-chart/total-revenue-chart.spec.js
@@ -13,7 +13,6 @@ import {
   mockRevenueData_NoChange,
 } from '../../../../../explainer-test-helper';
 import Analytics from '../../../../../../../utils/analytics/analytics';
-import userEvent from '@testing-library/user-event';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useInView } from 'react-intersection-observer';
 
@@ -25,6 +24,18 @@ class ResizeObserver {
 jest.mock('react-intersection-observer', () => ({
   useInView: jest.fn().mockReturnValue({ ref: jest.fn(), inView: false }),
 }));
+
+jest.mock('recharts', () => {
+  const RechartsModule = jest.requireActual('recharts');
+  return {
+    ...RechartsModule,
+    ResponsiveContainer: ({ children }) => (
+      <RechartsModule.ResponsiveContainer width={100} height={100}>
+        {children}
+      </RechartsModule.ResponsiveContainer>
+    ),
+  };
+});
 
 jest.useFakeTimers();
 describe('Total Revenue Chart', () => {
@@ -55,8 +66,7 @@ describe('Total Revenue Chart', () => {
   };
 
   it('chart fires on mouse over leave - for percentage of GDP', async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    const { findAllByText, getByText, findByTestId, findAllByTestId } = render(
+    const { findAllByText, getByText, findByTestId } = render(
       <ErrorBoundary>
         <TotalRevenueChart cpiDataByYear={mockCpiDataset} beaGDPData={mockBeaGDPDataForRevenueChart} copyPageData={mockPageFunction} />
       </ErrorBoundary>
@@ -64,23 +74,15 @@ describe('Total Revenue Chart', () => {
     await waitForElementToBeRemoved(() => getByText('Loading...'));
     const totalRevenue = await findAllByText('Total Revenue');
     expect(totalRevenue.length).toBe(3);
-    const customSlices = await findByTestId('customSlices');
-    expect(customSlices).toBeInTheDocument();
 
-    await user.tab();
-    await user.tab();
-    await user.keyboard('{Enter}');
-    const allSlices = await findAllByTestId('customSlice');
-    await user.tab();
-    expect(allSlices[0]).toHaveFocus();
-    // 2015 is in the header after slice was focused
-    const year = await findAllByText('2015');
-    expect(year.length).toBe(2);
+    const chart = await findByTestId('totalRevenueChartParent');
+    fireEvent.mouseOver(chart);
+    fireEvent.mouseLeave(chart);
+    expect(getByText('2022')).toBeInTheDocument();
   });
 
   it('chart fires on mouse over leave - for total revenue', async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    const { findAllByText, getByText, findByTestId, findAllByTestId } = render(
+    const { findAllByText, getByText, findByTestId } = render(
       <ErrorBoundary>
         <TotalRevenueChart cpiDataByYear={mockCpiDataset} beaGDPData={mockBeaGDPDataForRevenueChart} copyPageData={mockPageFunction} />
       </ErrorBoundary>
@@ -88,15 +90,10 @@ describe('Total Revenue Chart', () => {
     await waitForElementToBeRemoved(() => getByText('Loading...'));
     const totalRevenue = await findAllByText('Total Revenue');
     expect(totalRevenue.length).toBe(3);
-    expect(await findByTestId('customSlices')).toBeInTheDocument();
-    const allSlices = await findAllByTestId('customSlice');
-    await user.tab();
-    await user.tab();
-    await user.tab();
-    expect(allSlices[0]).toHaveFocus();
-    // 2015 is in the header after slice was focused
-    const year = await findAllByText('2015');
-    expect(year.length).toBe(2);
+    const chart = await findByTestId('totalRevenueChartParent');
+    fireEvent.mouseOver(chart);
+    fireEvent.mouseLeave(chart);
+    expect(getByText('2022')).toBeInTheDocument();
   });
 
   it('chart fires ga4 event on mouse over', async () => {
@@ -161,41 +158,18 @@ describe('Total Revenue Chart', () => {
   });
 
   it('renders the chart markers and data header labels', async () => {
-    const { findAllByText, getByText, findByText } = render(
+    useInView.mockReturnValue({ ref: jest.fn(), inView: true });
+    const { findAllByText, getByText, findByText, findByTestId } = render(
       <ErrorBoundary>
         <TotalRevenueChart cpiDataByYear={mockCpiDataset} beaGDPData={mockBeaGDPData} copyPageData={mockPageFunction} />
       </ErrorBoundary>
     );
     await waitForElementToBeRemoved(() => getByText('Loading...'));
+    const chart = await findByTestId('revenueLineChart');
+    expect(chart).toBeInTheDocument();
     expect(await findAllByText('Total Revenue')).toHaveLength(3);
     expect(await findAllByText('GDP')).toHaveLength(2);
     expect(await findByText('Fiscal Year')).toBeInTheDocument();
-  });
-
-  it('renders the CustomPoints layer', async () => {
-    const fetchSpy = jest.spyOn(global, 'fetch');
-    const { findByTestId } = render(
-      <ErrorBoundary>
-        <TotalRevenueChart cpiDataByYear={mockCpiDataset} beaGDPData={mockBeaGDPData} copyPageData={mockPageFunction} />
-      </ErrorBoundary>
-    );
-    await waitFor(() => expect(fetchSpy).toHaveBeenCalled);
-    const customPoints = await findByTestId('customPoints');
-    expect(customPoints).toBeInTheDocument();
-    expect(customPoints.querySelector('circle')?.length === 4);
-  });
-
-  it('renders the CustomSlices layer', async () => {
-    const fetchSpy = jest.spyOn(global, 'fetch');
-    const { findByTestId } = render(
-      <ErrorBoundary>
-        <TotalRevenueChart cpiDataByYear={mockCpiDataset} beaGDPData={mockBeaGDPData} copyPageData={mockPageFunction} />
-      </ErrorBoundary>
-    );
-    await waitFor(() => expect(fetchSpy).toHaveBeenCalled);
-    const customSlices = await findByTestId('customSlices');
-    expect(customSlices).toBeInTheDocument();
-    expect(customSlices?.querySelector('rect')?.length === 8);
   });
 
   it('renders the chart headers', async () => {
@@ -282,12 +256,13 @@ describe('Total Revenue Chart Revenue-to-GDP Ratio No Change', () => {
 
   it('renders the calloutText', async () => {
     const fetchSpy = jest.spyOn(global, 'fetch');
-    const { findByText } = render(
+    const { findByText, findByTestId } = render(
       <ErrorBoundary>
         <TotalRevenueChart cpiDataByYear={mockCpiDataset} beaGDPData={mockBeaGDPData} copyPageData={mockPageFunction} />
       </ErrorBoundary>
     );
     await waitFor(() => expect(fetchSpy).toHaveBeenCalled);
+    await findByTestId('totalRevenueChartParent');
     //If this is set, that means all 3 API calls were sucessful.
     expect(await findByText('Since 2015, the Revenue-to-GDP ratio has not changed, remaining at 20%.', { exact: false })).toBeInTheDocument();
   });


### PR DESCRIPTION
**JIRA Ticket:**

[FDG-11895](https://federal-spending-transparency.atlassian.net/browse/FDG-11894)

Merge the spending chart first

***The following are ALL required for the PR to be merged:***

- [ ] Provided testing instructions in JIRA ticket `if applicable`
- [ ] Provided mocks or additional information in JIRA ticket `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [ ] Verify all files are covered by at least 93% test coverage `if applicable`
- [ ] Verify that dashes are used for any visible defaults of evergreen values `if applicable`
- [ ] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
