### PR TITLE
FDG-11923 DTS data table switching from pivot view to All Data tables  is causing an issue with the pivot drop downs

### DIFF
--- a/src/components/dataset-data/dataset-data.spec.js
+++ b/src/components/dataset-data/dataset-data.spec.js
@@ -110,6 +110,24 @@ describe('DatasetData', () => {
     expect(tableTenSelect).toBeInTheDocument();
   });
 
+  it(`keeps the pivot options when switching to All Data Tables and back to the same table`, async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const { getByRole, getByTestId, queryByTestId, findByRole } = render(
+      <>
+        <DatasetDataComponent config={config} width={2000} setSelectedTableProp={setSelectedTableMock} location={mockLocation} />
+      </>
+    );
+    expect(getByTestId('pivotOptionsBar')).toBeInTheDocument();
+
+    await user.click(getByRole('button', { name: 'Table 1' }));
+    await user.click(await findByRole('button', { name: 'All Data Tables' }));
+    expect(queryByTestId('pivotOptionsBar')).not.toBeInTheDocument();
+
+    await user.click(getByRole('button', { name: 'All Data Tables' }));
+    await user.click(await findByRole('button', { name: 'Table 1' }));
+    expect(getByTestId('pivotOptionsBar')).toBeInTheDocument();
+  });
+
   it(`initializes the selected table to the first element in the apis array`, () => {
     const { getByRole } = render(
       <>

--- a/src/components/dataset-data/table-section-container/pivot-options/pivot-options.jsx
+++ b/src/components/dataset-data/table-section-container/pivot-options/pivot-options.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { containerBar, dropdownContainer, formControl, selectLabel } from './pivot-options.module.scss';
 import SelectControl from '../../../select-control/select-control';
 import Analytics from '../../../../utils/analytics/analytics';
@@ -59,8 +59,13 @@ const PivotOptions = ({ datasetName, table, pivotSelection, setSelectedPivot, pi
     }
   };
 
+  const lastInitialized = useRef({ table: null, pivotsUpdated: null });
+
   useEffect(() => {
     if (table && !table.allDataTables) {
+      const isNewTarget = lastInitialized.current.table !== table || lastInitialized.current.pivotsUpdated !== pivotsUpdated;
+      if (!isNewTarget && pivotSelection) return;
+      lastInitialized.current = { table, pivotsUpdated };
       const localPivotFields = getPivotFields(table);
       setPivotFields(localPivotFields);
       const pivot = {
@@ -70,7 +75,7 @@ const PivotOptions = ({ datasetName, table, pivotSelection, setSelectedPivot, pi
       setSelectedPivot(pivot);
       setPivotOptions(pivot.pivotView.dimensionField ? localPivotFields : [{ prettyName: '— N / A —' }]);
     }
-  }, [table, pivotsUpdated]);
+  }, [table, pivotsUpdated, pivotSelection]);
 
   return (
     <>

--- a/src/components/dataset-data/table-section-container/pivot-options/pivot-options.spec.js
+++ b/src/components/dataset-data/table-section-container/pivot-options/pivot-options.spec.js
@@ -281,6 +281,42 @@ describe('PivotOptions component does render children', () => {
     });
   });
 
+  it('reinitializes the pivot when it is cleared without the table changing', () => {
+    const PivotOptionsWithState = () => {
+      const [pivotSelection, setSelectedPivot] = React.useState({
+        pivotView: selectedTable.dataDisplays[1],
+        pivotValue: selectedTable.fields[3],
+      });
+      return (
+        <>
+          <button onClick={() => setSelectedPivot(null)}>clear pivot</button>
+          <PivotOptions table={selectedTable} pivotSelection={pivotSelection} setSelectedPivot={setSelectedPivot} />
+        </>
+      );
+    };
+
+    const { getByRole, getByTestId } = render(<PivotOptionsWithState />);
+    expect(getByTestId('pivotOptionsBar')).toBeInTheDocument();
+
+    fireEvent.click(getByRole('button', { name: 'clear pivot' }));
+
+    expect(getByTestId('pivotOptionsBar')).toBeInTheDocument();
+    // back to the table's default pivot view rather than the previously selected one
+    expect(getByRole('button', { name: `Change pivot view from ${selectedTable.dataDisplays[0].title}` })).toBeInTheDocument();
+  });
+
+  it('initializes the pivot once per table change', () => {
+    const setSelectedPivotSpy = jest.fn();
+    const otherTable = { ...selectedTable, dataDisplays: [...selectedTable.dataDisplays] };
+    const pivotSelection = { pivotView: selectedTable.dataDisplays[1], pivotValue: selectedTable.fields[3] };
+
+    const { rerender } = render(<PivotOptions table={selectedTable} pivotSelection={pivotSelection} setSelectedPivot={setSelectedPivotSpy} />);
+    expect(setSelectedPivotSpy).toHaveBeenCalledTimes(1);
+
+    rerender(<PivotOptions table={otherTable} pivotSelection={pivotSelection} setSelectedPivot={setSelectedPivotSpy} />);
+    expect(setSelectedPivotSpy).toHaveBeenCalledTimes(2);
+  });
+
   it('hides pivot options when all data tables is selected', () => {
     const setSelectedPivotSpy = jest.fn();
     const selectedPivotView = selectedTable.dataDisplays[4];


### PR DESCRIPTION
**JIRA Ticket:**

[FDG-11923](https://federal-spending-transparency.atlassian.net/browse/FDG-11923)

***The following are ALL required for the PR to be merged:***

- [ ] Provided testing instructions in JIRA ticket `if applicable`
- [ ] Provided mocks or additional information in JIRA ticket `if applicable`
- [ ] Verified cross-browser compatibility: Chrome, Safari, Firefox, Edge
- [ ] Verified mobile/tablet/desktop/monitor responsiveness
- [ ] Verified that this PR does not create any *new* accessibility issues (via Axe Chrome)
- [ ] Verify all files are covered by at least 93% test coverage `if applicable`
- [ ] Verify that dashes are used for any visible defaults of evergreen values `if applicable`
- [ ] Check for code quality
       + Watch out for irrelevant changes
       + Take time to understand the logic and flow; be on guard for pitfalls
       + Look at handoff between components (esp. number of props)
       + Watch out for literals (vs. variables) for css specs  `if applicable`
